### PR TITLE
Refactor mutation

### DIFF
--- a/apps/admin/pages/api/auth/register.ts
+++ b/apps/admin/pages/api/auth/register.ts
@@ -1,4 +1,4 @@
-import { mutation, sessionOptions, getAuth } from '@wsvvrijheid/utils'
+import { sessionOptions, getAuth, createMutation } from '@wsvvrijheid/utils'
 import axios from 'axios'
 import { withIronSessionApiRoute } from 'iron-session/next'
 import { NextApiResponse, NextApiRequest } from 'next'
@@ -23,9 +23,9 @@ const registerRoute = async (req: NextApiRequest, res: NextApiResponse) => {
     const token = response.data.jwt
     const userId = response.data.user?.id
 
-    await mutation(token).post('api/artists', {
-      data: { user: userId, name: trimmedName },
-    })
+    const body = { user: userId, name: trimmedName }
+
+    await createMutation('api/users', body, token)
 
     const auth = await getAuth(email, password)
 

--- a/apps/admin/pages/api/auth/social-auth/[provider].ts
+++ b/apps/admin/pages/api/auth/social-auth/[provider].ts
@@ -1,9 +1,9 @@
 import { AuthResponse } from '@wsvvrijheid/types'
 import {
   fetcher,
-  mutation,
   sessionOptions,
   getSessionUser,
+  createMutation,
 } from '@wsvvrijheid/utils'
 import { withIronSessionApiRoute } from 'iron-session/next'
 import { NextApiResponse, NextApiRequest } from 'next'
@@ -36,12 +36,11 @@ const route = async (req: NextApiRequest, res: NextApiResponse) => {
       const sessionUser = await getSessionUser(token)
 
       if (!sessionUser.artistId) {
-        await mutation(token).post('api/artists', {
-          data: {
-            user: userId,
-            name: socialLoginResponse.data.user?.username,
-          },
-        })
+        const body = {
+          user: userId,
+          name: socialLoginResponse.data.user?.username,
+        }
+        await createMutation('api/artists', body, token)
       }
 
       const auth = { user: sessionUser, token, isLoggedIn: true }

--- a/libs/types/src/strapi.ts
+++ b/libs/types/src/strapi.ts
@@ -155,6 +155,7 @@ export type StrapiMutationResponse<T extends StrapiModel> = {
   meta: Record<string, unknown>
 }
 
+export type StrapiEmailUrl = 'email'
 export type StrapiProviders = 'instagram' | 'facebook' | 'google' | 'twitter'
 export type StrapiSingleUrl = 'term' | 'privacy' | 'trend'
 export type StrapiAuthUrl =
@@ -199,4 +200,8 @@ export type StrapiCollectionUrl =
   | 'volunteers'
   | 'votes'
 
-export type StrapiUrl = StrapiSingleUrl | StrapiCollectionUrl | StrapiAuthUrl
+export type StrapiUrl =
+  | StrapiSingleUrl
+  | StrapiCollectionUrl
+  | StrapiAuthUrl
+  | StrapiEmailUrl

--- a/libs/ui/src/templates/JoinTemplate/JoinTemplate.tsx
+++ b/libs/ui/src/templates/JoinTemplate/JoinTemplate.tsx
@@ -12,8 +12,8 @@ import {
 } from '@chakra-ui/react'
 import { useMutation } from '@tanstack/react-query'
 import { StrapiLocale, Volunteer } from '@wsvvrijheid/types'
-import { Job, Platform } from '@wsvvrijheid/types'
-import { mutation, usePlatforms, toastMessage } from '@wsvvrijheid/utils'
+import { Job } from '@wsvvrijheid/types'
+import { usePlatforms, toastMessage, createMutation } from '@wsvvrijheid/utils'
 import { useTranslation } from 'next-i18next'
 import { useRouter } from 'next/router'
 import { v4 as uuidV4 } from 'uuid'
@@ -27,9 +27,9 @@ import {
 } from '../../components'
 import { JoinTemplateProps } from './types'
 
-type VolunteerRequest = {
-  username: Volunteer['username']
-  heardFrom: Volunteer['heardFrom']
+type VolunteerBody = {
+  username: string
+  heardFrom: string
 } & Omit<JoinFormFieldValues, 'heardFrom'>
 
 export const JoinTemplate: FC<JoinTemplateProps> = ({ title }) => {
@@ -38,12 +38,13 @@ export const JoinTemplate: FC<JoinTemplateProps> = ({ title }) => {
 
   const platformsResult = usePlatforms()
 
-  const platforms: Platform[] = platformsResult.data || []
-  const jobs: Job[] = (platforms?.flatMap(p => p.jobs) as Job[]) || []
+  const platforms = platformsResult.data || []
+  const jobs = (platforms?.flatMap(p => p.jobs) as Job[]) || []
 
   const { mutate, isLoading, isSuccess } = useMutation(
     ['create-volunteer'],
-    (data: VolunteerRequest) => mutation().post('api/volunteers', { data }),
+    (body: VolunteerBody) =>
+      createMutation<Volunteer, VolunteerBody>('api/volunteers', body),
   )
 
   const onSubmit = (data: JoinFormFieldValues) => {

--- a/libs/utils/src/lib/mutation.ts
+++ b/libs/utils/src/lib/mutation.ts
@@ -2,51 +2,85 @@ import {
   StrapiLocale,
   StrapiModel,
   StrapiMutationResponse,
+  StrapiUrl,
 } from '@wsvvrijheid/types'
 
 import { fetcher } from './fetcher'
 
-type MutationReturnType<T> = {
-  post: (url: string, data: Record<string, unknown>) => Promise<T>
-  put: (url: string, id: number, data: Record<string, unknown>) => Promise<T>
-  delete: (url: string, id: number) => Promise<T>
-  localize: (
-    url: string,
-    id: number,
-    locale: StrapiLocale,
-    data: Record<string, unknown>,
-  ) => Promise<T>
+type Method = 'post' | 'put' | 'delete' | 'localize'
+
+type MutationParams<D> = {
+  body?: D
+  id?: number
+  locale?: StrapiLocale
+  method: Method
+  token?: string
+  url: `api/${StrapiUrl}`
 }
 
-export const mutation = <T extends StrapiModel>(
-  token?: string,
-): MutationReturnType<T> => ({
-  post: async (url, data) => {
-    const response = await fetcher(token).post<StrapiMutationResponse<T>>(
-      `/${url}`,
-      data,
-    )
-    return response.data?.data || null
-  },
-  put: async (url, id, data) => {
-    const response = await fetcher(token).put<StrapiMutationResponse<T>>(
-      `/${url}/${id}`,
-      data,
-    )
-    return response.data?.data || null
-  },
-  delete: async (url, id) => {
-    const response = await fetcher(token).delete<StrapiMutationResponse<T>>(
-      `/${url}/${id}`,
-    )
-    return response.data?.data || null
-  },
-  // https://docs.strapi.io/developer-docs/latest/plugins/i18n.html#creating-a-localization-for-an-existing-entry
-  localize: async (url, id, locale, data) => {
+// T is the type of the model to be returned
+// D is the type of the data to be sent
+const mutation = async <T extends StrapiModel, D = unknown>({
+  body,
+  id,
+  locale,
+  method,
+  token,
+  url,
+}: MutationParams<D>) => {
+  //  Throw an error if the body is not provided
+  if (method !== 'delete' && !body) {
+    throw new Error(`Body is required for ${method} method`)
+  }
+
+  //  Throw an error if the id is not provided
+  if (method !== 'post' && !id) {
+    throw new Error(`Id is required for ${method} method`)
+  }
+
+  if (method === 'localize') {
+    // https://docs.strapi.io/developer-docs/latest/plugins/i18n.html#creating-a-localization-for-an-existing-entry
     const response = await fetcher(token).post<StrapiMutationResponse<T>>(
       `/${url}/${id}/localizations`,
-      { ...data, locale },
+      { ...body, locale }, // TODO localization body doesn't seem to have data key. Double check this
     )
     return response.data?.data || null
-  },
-})
+  }
+
+  const requestUrl = id ? `/${url}/${id}` : `/${url}`
+  const requestBody = body ? { data: body } : {}
+
+  const response = await fetcher(token)[method]<StrapiMutationResponse<T>>(
+    requestUrl,
+    requestBody,
+  )
+
+  return response.data?.data || null
+}
+
+export const createMutation = <T extends StrapiModel, D = unknown>(
+  url: `api/${StrapiUrl}`,
+  body: D,
+  token?: string,
+) => mutation<T, D>({ url, method: 'post', body, token })
+
+export const updateMutation = <T extends StrapiModel, D = unknown>(
+  url: `api/${StrapiUrl}`,
+  id: number,
+  body: D,
+  token?: string,
+) => mutation<T, D>({ url, method: 'put', id, body, token })
+
+export const deleteMutation = <T extends StrapiModel>(
+  url: `api/${StrapiUrl}`,
+  id: number,
+  token?: string,
+) => mutation<T>({ url, method: 'delete', id, token })
+
+export const localizeMutation = <T extends StrapiModel, D = unknown>(
+  url: `api/${StrapiUrl}`,
+  id: number,
+  locale: StrapiLocale,
+  body: D,
+  token?: string,
+) => mutation<T, D>({ url, method: 'localize', id, locale, body, token })

--- a/libs/utils/src/services/art/comment.ts
+++ b/libs/utils/src/services/art/comment.ts
@@ -1,7 +1,7 @@
 import { useMutation } from '@tanstack/react-query'
 import { Comment } from '@wsvvrijheid/types'
 
-import { mutation } from '../../lib'
+import { createMutation } from '../../lib'
 
 type CreateArtCommentProps = {
   content: string
@@ -19,19 +19,14 @@ const createArtComment = ({
   userId,
 }: CreateArtCommentProps) => {
   if (userId) {
-    return mutation<Comment>().post(`api/comments`, {
-      data: { content, art: id, user: userId },
-    })
+    const body = { content, art: id, user: userId }
+
+    return createMutation<Comment, typeof body>('api/comments', body)
   }
 
-  return mutation<Comment>().post(`api/comments`, {
-    data: {
-      content,
-      name,
-      email,
-      art: id,
-    },
-  })
+  const body = { content, name, email, art: id }
+
+  return createMutation<Comment, typeof body>('api/comments', body)
 }
 
 export const useArtCommentMutation = () => {

--- a/libs/utils/src/services/art/delete.ts
+++ b/libs/utils/src/services/art/delete.ts
@@ -2,10 +2,10 @@ import { useToast } from '@chakra-ui/react'
 import { useMutation, useQueryClient, QueryKey } from '@tanstack/react-query'
 import { Art } from '@wsvvrijheid/types'
 
-import { mutation } from '../../lib'
+import { deleteMutation } from '../../lib'
 
 export const deleteArt = ({ id }: { id: number }) =>
-  mutation<Art>().delete('api/arts', id)
+  deleteMutation<Art>('api/arts', id)
 
 export const useDeleteArt = (queryKey: QueryKey) => {
   const queryClient = useQueryClient()

--- a/libs/utils/src/services/art/like.ts
+++ b/libs/utils/src/services/art/like.ts
@@ -2,7 +2,7 @@ import { QueryKey, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Art, SessionUser } from '@wsvvrijheid/types'
 import { useLocalStorage } from 'react-use'
 
-import { mutation } from '../../lib'
+import { updateMutation } from '../../lib'
 
 type LikersMutationArgs = {
   id: number
@@ -14,15 +14,17 @@ type LikesMutationArgs = {
   likes: number
 }
 
-const likeArtByUser = ({ id, likers }: LikersMutationArgs) =>
-  mutation<Art>().put('api/arts', id, {
-    data: { likers },
-  })
+const likeArtByUser = ({ id, likers }: LikersMutationArgs) => {
+  const body = { likers }
 
-const likeArtPublic = ({ id, likes }: LikesMutationArgs) =>
-  mutation<Art>().put('api/arts', id, {
-    data: { likes },
-  })
+  return updateMutation<Art, typeof body>('api/arts', id, body)
+}
+
+const likeArtPublic = ({ id, likes }: LikesMutationArgs) => {
+  const body = { likes }
+
+  return updateMutation<Art, typeof body>('api/arts', id, body)
+}
 
 const useLikeArtByUserMutation = () => {
   return useMutation({

--- a/libs/utils/src/services/art/publish.ts
+++ b/libs/utils/src/services/art/publish.ts
@@ -2,10 +2,13 @@ import { useToast } from '@chakra-ui/react'
 import { useMutation, useQueryClient, QueryKey } from '@tanstack/react-query'
 import { Art } from '@wsvvrijheid/types'
 
-import { mutation } from '../../lib'
+import { updateMutation } from '../../lib'
 
-export const publishArt = ({ id }: { id: number }) =>
-  mutation<Art>().put('api/arts', id, { data: { publishedAt: new Date() } })
+export const publishArt = ({ id }: { id: number }) => {
+  const body = { publishedAt: new Date() }
+
+  return updateMutation<Art, typeof body>('api/arts', id, body)
+}
 
 export const usePublishArt = (queryKey: QueryKey, id: number) => {
   const queryClient = useQueryClient()

--- a/libs/utils/src/services/art/unpublish.ts
+++ b/libs/utils/src/services/art/unpublish.ts
@@ -2,10 +2,13 @@ import { useToast } from '@chakra-ui/react'
 import { useMutation, useQueryClient, QueryKey } from '@tanstack/react-query'
 import { Art } from '@wsvvrijheid/types'
 
-import { mutation } from '../../lib'
+import { updateMutation } from '../../lib'
 
-export const unpublishArt = ({ id }: { id: number }) =>
-  mutation<Art>().put('api/arts', id, { data: { publishedAt: null } })
+export const unpublishArt = ({ id }: { id: number }) => {
+  const body = { publishedAt: null }
+
+  return updateMutation<Art, typeof body>('api/arts', id, body)
+}
 
 export const useUnpublishArt = (queryKey: QueryKey, id: number) => {
   const queryClient = useQueryClient()

--- a/libs/utils/src/services/art/view.ts
+++ b/libs/utils/src/services/art/view.ts
@@ -4,13 +4,14 @@ import { Art } from '@wsvvrijheid/types'
 import { useRouter } from 'next/router'
 import { useLocalStorage } from 'react-use'
 
-import { mutation } from '../../lib'
+import { updateMutation } from '../../lib'
 import { useArtBySlug } from './getBySlug'
 
-export const viewArt = async (art: Art) =>
-  mutation<Art>().put('api/arts', art.id, {
-    data: { views: (art.views || 0) + 1 },
-  })
+export const viewArt = async (art: Art) => {
+  const body = { views: (art.views || 0) + 1 }
+
+  return updateMutation<Art, typeof body>('api/arts', art.id, body)
+}
 
 export const useViewArtMutation = async () => {
   const queryClient = useQueryClient()
@@ -25,7 +26,7 @@ export const useViewArtMutation = async () => {
 
   const { mutate } = useMutation({
     mutationKey: ['viewart', art?.id],
-    mutationFn: (art: Art) => viewArt(art),
+    mutationFn: viewArt,
     onSuccess: () => {
       art && setArtStorage([...(artStorage || []), art.id])
       queryClient.invalidateQueries(['art', locale, slug])

--- a/libs/utils/src/services/blog/like.ts
+++ b/libs/utils/src/services/blog/like.ts
@@ -2,7 +2,7 @@ import { QueryKey, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Blog, SessionUser } from '@wsvvrijheid/types'
 import { useLocalStorage } from 'react-use'
 
-import { mutation } from '../../lib'
+import { updateMutation } from '../../lib'
 
 type LikersMutationArgs = {
   id: number
@@ -18,15 +18,15 @@ type LikesMutationArgs = {
 const likeBlogByUser = async ({ id, likers, user }: LikersMutationArgs) => {
   if (!user) return
 
-  return mutation<Blog>().put('api/arts', id, {
-    data: { likers },
-  })
+  const body = { likers }
+
+  return updateMutation<Blog, typeof body>('api/blogs', id, body)
 }
 
 const likeBlogPublic = async ({ id, likes }: LikesMutationArgs) => {
-  return mutation<Blog>().put('api/blogs', id, {
-    data: { likes },
-  })
+  const body = { likes }
+
+  return updateMutation<Blog, typeof body>('api/blogs', id, body)
 }
 
 const useLikeBlogByUserMutation = () => {

--- a/libs/utils/src/services/blog/view.ts
+++ b/libs/utils/src/services/blog/view.ts
@@ -4,13 +4,14 @@ import { Blog } from '@wsvvrijheid/types'
 import { useRouter } from 'next/router'
 import { useLocalStorage } from 'react-use'
 
-import { mutation } from '../../lib'
+import { updateMutation } from '../../lib'
 import { useGetBlog } from './getBySlug'
 
-export const viewBlog = async (blog: Blog) =>
-  mutation<Blog>().put('api/blogs', blog.id, {
-    data: { views: (blog.views || 0) + 1 },
-  })
+export const viewBlog = async (blog: Blog) => {
+  const body = { views: (blog.views || 0) + 1 }
+
+  return updateMutation<Blog, { views: number }>('api/blogs', blog.id, body)
+}
 
 export const useViewBlog = async () => {
   const queryClient = useQueryClient()

--- a/libs/utils/src/services/email.ts
+++ b/libs/utils/src/services/email.ts
@@ -1,7 +1,7 @@
 import { EMAIL_SENDER, EMAIL_RECEIVER } from '@wsvvrijheid/config'
 import { MergeExclusive } from 'type-fest'
 
-import { mutation } from '../lib'
+import { createMutation } from '../lib'
 
 type BaseEmailData = {
   // If we don't specify the receiver,
@@ -24,9 +24,12 @@ interface EmailDataHtml extends BaseEmailData {
 // Allow only one of text or html
 export type EmailData = MergeExclusive<EmailDataText, EmailDataHtml>
 
-export const sendEmail = async (data: EmailData) =>
-  mutation().post(`api/email`, {
+export const sendEmail = async (data: EmailData) => {
+  const body = {
     ...data,
     to: data.to || EMAIL_RECEIVER || EMAIL_SENDER,
     from: EMAIL_SENDER,
-  })
+  }
+
+  createMutation('api/email', body)
+}


### PR DESCRIPTION
I refactored `mutation` function. We can now use more specific mutation function instead of `mutation()[method](...)`.

We have now:

1. createMutation
2. updateMutation
3. deleteMutation
4. localizeMutation

Examples:

```ts
// Create a new blog
const createdBlogBody = { title, description, content, slug, categories, author }
createMutation<Blog, typeof createdBlogBody>('api/blogs', createdBlogBody)

// Update blog's description
const updatedBlogBody = { description }
updateMutation<Blog, typeof updatedBlogBody>('api/blogs', id, updatedBlogBody)

// Delete a blog
deleteMutation<Blog>('api/blogs', id)
```

I'll later create ModelBody types for each model's body types to be used in `post` and `put` mutations. By this way, we will no longer be worrying about which fields are required to create or update a model.

Perhaps this process could be done by using some tools, like [graphql-codegen](https://www.the-guild.dev/graphql/codegen), but this way could also be a good challenge for us to develop our TypeScript skills.