### PR TITLE
Auth Redux Store

### DIFF
--- a/apps/admin/pages/_app.tsx
+++ b/apps/admin/pages/_app.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { ChakraProvider, createStandaloneToast } from '@chakra-ui/react'
 import {
@@ -8,9 +8,11 @@ import {
 } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { defaultSeo, themes } from '@wsvvrijheid/config'
+import { checkAuth, store } from '@wsvvrijheid/utils'
 import { appWithTranslation } from 'next-i18next'
 import { DefaultSeo } from 'next-seo'
 import { useRouter } from 'next/router'
+import { Provider as ReduxProvider } from 'react-redux'
 
 import i18nConfig from '../next-i18next.config'
 import '@splidejs/splide/dist/css/themes/splide-default.min.css'
@@ -22,14 +24,20 @@ function MyApp({ Component, pageProps }) {
   const [queryClient] = useState(() => new QueryClient())
   const { locale } = useRouter()
 
+  useEffect(() => {
+    store.dispatch(checkAuth())
+  }, [])
+
   return (
     <QueryClientProvider client={queryClient}>
       <Hydrate state={pageProps.dehydratedState}>
-        <ChakraProvider theme={themes.admin}>
-          <DefaultSeo {...defaultSeo.admin[locale]} />
-          <Component {...pageProps} />
-          <ToastContainer />
-        </ChakraProvider>
+        <ReduxProvider store={store}>
+          <ChakraProvider theme={themes.admin}>
+            <DefaultSeo {...defaultSeo.admin[locale]} />
+            <Component {...pageProps} />
+            <ToastContainer />
+          </ChakraProvider>
+        </ReduxProvider>
       </Hydrate>
       <ReactQueryDevtools />
     </QueryClientProvider>

--- a/apps/admin/pages/accounts.tsx
+++ b/apps/admin/pages/accounts.tsx
@@ -1,11 +1,9 @@
 import { Box } from '@chakra-ui/react'
-import { useAuth, AdminLayout } from '@wsvvrijheid/ui'
+import { AdminLayout } from '@wsvvrijheid/ui'
 
 const AccountsPage = () => {
-  const { user, isLoading } = useAuth()
-
   return (
-    <AdminLayout title="Accounts" user={user} isLoading={!user || isLoading}>
+    <AdminLayout title="Accounts">
       <Box>Accounts</Box>
     </AdminLayout>
   )

--- a/apps/admin/pages/arts.tsx
+++ b/apps/admin/pages/arts.tsx
@@ -2,14 +2,13 @@ import { useEffect, useState } from 'react'
 
 import { MenuItem } from '@chakra-ui/react'
 import { ApprovalStatus, StrapiLocale, Sort } from '@wsvvrijheid/types'
-import { useAuth, AdminLayout, ArtsTable } from '@wsvvrijheid/ui'
+import { AdminLayout, ArtsTable } from '@wsvvrijheid/ui'
 import { useArts } from '@wsvvrijheid/utils'
 import { useRouter } from 'next/router'
 import { FaArrowDown, FaArrowUp } from 'react-icons/fa'
 import { useUpdateEffect } from 'react-use'
 
 const ArtsPage = () => {
-  const { user, isLoading } = useAuth()
   const { query } = useRouter()
   const [currentPage, setCurrentPage] = useState<number>()
   // Client side query params (?status=pending)
@@ -57,8 +56,6 @@ const ArtsPage = () => {
   return (
     <AdminLayout
       title={`${status} Arts`}
-      user={user}
-      isLoading={!user || isLoading}
       headerProps={{
         onSearch: handleSearch,
         onLanguageSwitch: locale => setLocale(locale),
@@ -76,7 +73,6 @@ const ArtsPage = () => {
       <ArtsTable
         data={mappedArts}
         queryKey={queryKey}
-        user={user}
         totalCount={totalCount}
         currentPage={currentPage}
         setCurrentPage={setCurrentPage}

--- a/apps/admin/pages/arts/collections/index.tsx
+++ b/apps/admin/pages/arts/collections/index.tsx
@@ -1,12 +1,11 @@
 import { useState } from 'react'
 
 import { StrapiLocale, Sort } from '@wsvvrijheid/types'
-import { useAuth, AdminLayout, CollectionsTable } from '@wsvvrijheid/ui'
+import { AdminLayout, CollectionsTable } from '@wsvvrijheid/ui'
 import { useCollectionsByFilterAndSort } from '@wsvvrijheid/utils'
 import { useUpdateEffect } from 'react-use'
 
 const CollectionsPage = () => {
-  const { user, isLoading } = useAuth()
   const [currentPage, setCurrentPage] = useState<number>()
   const defaultLocale: StrapiLocale = 'tr'
 
@@ -41,8 +40,6 @@ const CollectionsPage = () => {
   return (
     <AdminLayout
       title="Collections"
-      user={user}
-      isLoading={!user || isLoading}
       headerProps={{
         onSearch: handleSearch,
         onLanguageSwitch: locale => setLocale(locale),

--- a/apps/admin/pages/caps-maker.tsx
+++ b/apps/admin/pages/caps-maker.tsx
@@ -1,11 +1,9 @@
 import { Box } from '@chakra-ui/react'
-import { useAuth, AdminLayout } from '@wsvvrijheid/ui'
+import { AdminLayout } from '@wsvvrijheid/ui'
 
 const CapsMakerPage = () => {
-  const { user, isLoading } = useAuth()
-
   return (
-    <AdminLayout title="CapsMaker" user={user} isLoading={!user || isLoading}>
+    <AdminLayout title="CapsMaker">
       <Box>CapsMaker</Box>
     </AdminLayout>
   )

--- a/apps/admin/pages/competitions.tsx
+++ b/apps/admin/pages/competitions.tsx
@@ -1,15 +1,9 @@
 import { Box } from '@chakra-ui/react'
-import { useAuth, AdminLayout } from '@wsvvrijheid/ui'
+import { AdminLayout } from '@wsvvrijheid/ui'
 
 const CompetitionsPage = () => {
-  const { user, isLoading } = useAuth()
-
   return (
-    <AdminLayout
-      title="Competitions"
-      user={user}
-      isLoading={!user || isLoading}
-    >
+    <AdminLayout title="Competitions">
       <Box>Competitions</Box>
     </AdminLayout>
   )

--- a/apps/admin/pages/content-maker/human-rights.tsx
+++ b/apps/admin/pages/content-maker/human-rights.tsx
@@ -1,11 +1,9 @@
 import { Box } from '@chakra-ui/react'
-import { useAuth, AdminLayout } from '@wsvvrijheid/ui'
+import { AdminLayout } from '@wsvvrijheid/ui'
 
 const HumanRightsPage = () => {
-  const { user, isLoading } = useAuth()
-
   return (
-    <AdminLayout title="HumanRights" user={user} isLoading={!user || isLoading}>
+    <AdminLayout title="HumanRights">
       <Box>HumanRights</Box>
     </AdminLayout>
   )

--- a/apps/admin/pages/content-maker/news.tsx
+++ b/apps/admin/pages/content-maker/news.tsx
@@ -1,11 +1,9 @@
 import { Box } from '@chakra-ui/react'
-import { useAuth, AdminLayout } from '@wsvvrijheid/ui'
+import { AdminLayout } from '@wsvvrijheid/ui'
 
 const NewsPage = () => {
-  const { user, isLoading } = useAuth()
-
   return (
-    <AdminLayout title="News" user={user} isLoading={!user || isLoading}>
+    <AdminLayout title="News">
       <Box>News</Box>
     </AdminLayout>
   )

--- a/apps/admin/pages/hashtags/main.tsx
+++ b/apps/admin/pages/hashtags/main.tsx
@@ -1,11 +1,9 @@
 import { Box } from '@chakra-ui/react'
-import { useAuth, AdminLayout } from '@wsvvrijheid/ui'
+import { AdminLayout } from '@wsvvrijheid/ui'
 
 const MainHashtagPage = () => {
-  const { user, isLoading } = useAuth()
-
   return (
-    <AdminLayout title="MainHashtag" user={user} isLoading={!user || isLoading}>
+    <AdminLayout title="MainHashtag">
       <Box>MainHashtag</Box>
     </AdminLayout>
   )

--- a/apps/admin/pages/hashtags/posts.tsx
+++ b/apps/admin/pages/hashtags/posts.tsx
@@ -1,15 +1,9 @@
 import { Box } from '@chakra-ui/react'
-import { useAuth, AdminLayout } from '@wsvvrijheid/ui'
+import { AdminLayout } from '@wsvvrijheid/ui'
 
 const HashtagPostsPage = () => {
-  const { user, isLoading } = useAuth()
-
   return (
-    <AdminLayout
-      title="HashtagPosts"
-      user={user}
-      isLoading={!user || isLoading}
-    >
+    <AdminLayout title="HashtagPosts">
       <Box>HashtagPosts</Box>
     </AdminLayout>
   )

--- a/apps/admin/pages/index.tsx
+++ b/apps/admin/pages/index.tsx
@@ -1,11 +1,9 @@
 import { Box } from '@chakra-ui/react'
-import { useAuth, AdminLayout } from '@wsvvrijheid/ui'
+import { AdminLayout } from '@wsvvrijheid/ui'
 
 const Index = () => {
-  const { user, isLoading } = useAuth()
-
   return (
-    <AdminLayout title="Dashboard" user={user} isLoading={!user || isLoading}>
+    <AdminLayout title="Dashboard">
       <Box>Dashboard</Box>
     </AdminLayout>
   )

--- a/apps/admin/pages/translates/activities.tsx
+++ b/apps/admin/pages/translates/activities.tsx
@@ -1,15 +1,9 @@
 import { Box } from '@chakra-ui/react'
-import { useAuth, AdminLayout } from '@wsvvrijheid/ui'
+import { AdminLayout } from '@wsvvrijheid/ui'
 
 const ActivitiesTranslatePage = () => {
-  const { user, isLoading } = useAuth()
-
   return (
-    <AdminLayout
-      title="ActivitiesTranslatePage"
-      user={user}
-      isLoading={!user || isLoading}
-    >
+    <AdminLayout title="ActivitiesTranslatePage">
       <Box>ActivitiesTranslatePage</Box>
     </AdminLayout>
   )

--- a/apps/admin/pages/translates/announcements.tsx
+++ b/apps/admin/pages/translates/announcements.tsx
@@ -1,15 +1,9 @@
 import { Box } from '@chakra-ui/react'
-import { useAuth, AdminLayout } from '@wsvvrijheid/ui'
+import { AdminLayout } from '@wsvvrijheid/ui'
 
 const AnnouncementsTranslatePage = () => {
-  const { user, isLoading } = useAuth()
-
   return (
-    <AdminLayout
-      title="AnnouncementsTranslatePage"
-      user={user}
-      isLoading={!user || isLoading}
-    >
+    <AdminLayout title="AnnouncementsTranslatePage">
       <Box>AnnouncementsTranslatePage</Box>
     </AdminLayout>
   )

--- a/apps/admin/pages/translates/arts.tsx
+++ b/apps/admin/pages/translates/arts.tsx
@@ -1,15 +1,9 @@
 import { Box } from '@chakra-ui/react'
-import { useAuth, AdminLayout } from '@wsvvrijheid/ui'
+import { AdminLayout } from '@wsvvrijheid/ui'
 
 const ArtsTranslatePage = () => {
-  const { user, isLoading } = useAuth()
-
   return (
-    <AdminLayout
-      title="ArtsTranslatePage"
-      user={user}
-      isLoading={!user || isLoading}
-    >
+    <AdminLayout title="ArtsTranslatePage">
       <Box>ArtsTranslatePage</Box>
     </AdminLayout>
   )

--- a/apps/admin/pages/translates/blogs.tsx
+++ b/apps/admin/pages/translates/blogs.tsx
@@ -1,15 +1,9 @@
 import { Box } from '@chakra-ui/react'
-import { useAuth, AdminLayout } from '@wsvvrijheid/ui'
+import { AdminLayout } from '@wsvvrijheid/ui'
 
 const BlogsTranslatePage = () => {
-  const { user, isLoading } = useAuth()
-
   return (
-    <AdminLayout
-      title="BlogsTranslatePage"
-      user={user}
-      isLoading={!user || isLoading}
-    >
+    <AdminLayout title="BlogsTranslatePage">
       <Box>BlogTranslatePage</Box>
     </AdminLayout>
   )

--- a/apps/admin/pages/translates/posts.tsx
+++ b/apps/admin/pages/translates/posts.tsx
@@ -1,15 +1,9 @@
 import { Box } from '@chakra-ui/react'
-import { useAuth, AdminLayout } from '@wsvvrijheid/ui'
+import { AdminLayout } from '@wsvvrijheid/ui'
 
 const PostsTranslatePage = () => {
-  const { user, isLoading } = useAuth()
-
   return (
-    <AdminLayout
-      title="PostsTranslatePage"
-      user={user}
-      isLoading={!user || isLoading}
-    >
+    <AdminLayout title="PostsTranslatePage">
       <Box>PostsTranslatePage</Box>
     </AdminLayout>
   )

--- a/apps/foundation/components/Layout/Layout.tsx
+++ b/apps/foundation/components/Layout/Layout.tsx
@@ -1,7 +1,8 @@
 import { FC, PropsWithChildren } from 'react'
 
 import { menus, socialLinks } from '@wsvvrijheid/config'
-import { Layout as AppLayout, useAuth } from '@wsvvrijheid/ui'
+import { Layout as AppLayout } from '@wsvvrijheid/ui'
+import { useAuthSelector } from '@wsvvrijheid/utils'
 import axios from 'axios'
 import { NextSeoProps } from 'next-seo'
 import { useRouter } from 'next/router'
@@ -20,7 +21,7 @@ export const Layout: FC<LayoutProps> = ({
   hasScroll,
   seo,
 }) => {
-  const auth = useAuth()
+  const auth = useAuthSelector()
   const router = useRouter()
 
   const logOut = () => {

--- a/apps/foundation/pages/_app.tsx
+++ b/apps/foundation/pages/_app.tsx
@@ -8,10 +8,11 @@ import {
 } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { defaultSeo, themes } from '@wsvvrijheid/config'
-import { pageview } from '@wsvvrijheid/utils'
+import { checkAuth, pageview, store } from '@wsvvrijheid/utils'
 import { appWithTranslation } from 'next-i18next'
 import { DefaultSeo } from 'next-seo'
 import { useRouter } from 'next/router'
+import { Provider as ReduxProvider } from 'react-redux'
 
 import '@splidejs/splide/dist/css/themes/splide-default.min.css'
 import '@splidejs/react-splide/css'
@@ -24,6 +25,10 @@ function MyApp({ Component, pageProps }) {
   const router = useRouter()
 
   useEffect(() => {
+    store.dispatch(checkAuth())
+  }, [])
+
+  useEffect(() => {
     const handleRouteChange = url => pageview(url)
 
     router.events.on('routeChangeComplete', handleRouteChange)
@@ -33,11 +38,13 @@ function MyApp({ Component, pageProps }) {
   return (
     <QueryClientProvider client={queryClient}>
       <Hydrate state={pageProps.dehydratedState}>
-        <ChakraProvider theme={themes.wsvvrijheid}>
-          <DefaultSeo {...defaultSeo.wsvvrijheid[router.locale]} />
-          <Component {...pageProps} />
-          <ToastContainer />
-        </ChakraProvider>
+        <ReduxProvider store={store}>
+          <ChakraProvider theme={themes.wsvvrijheid}>
+            <DefaultSeo {...defaultSeo.wsvvrijheid[router.locale]} />
+            <Component {...pageProps} />
+            <ToastContainer />
+          </ChakraProvider>
+        </ReduxProvider>
       </Hydrate>
       <ReactQueryDevtools />
     </QueryClientProvider>

--- a/apps/foundation/pages/blog/[slug].tsx
+++ b/apps/foundation/pages/blog/[slug].tsx
@@ -8,7 +8,7 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { MDXRemoteSerializeResult } from 'next-mdx-remote'
 import { serialize } from 'next-mdx-remote/serialize'
 import { NextSeoProps } from 'next-seo'
-import { GetStaticPropsContext } from 'next/types'
+import { GetStaticPaths, GetStaticProps } from 'next/types'
 
 import { Layout } from '../../components'
 import i18nConfig from '../../next-i18next.config'
@@ -26,12 +26,9 @@ const BlogDetailPage: FC<BlogPageProps> = ({
   authorBlogs,
   source,
 }) => {
-  // const { user } = useAuth()
-  //TODO: @ekrem user integration will be done
   return (
     <Layout seo={seo}>
       <BlogDetailTemplate
-        auth={null}
         queryKey={queryKey}
         authorBlogs={authorBlogs}
         source={source}
@@ -42,8 +39,8 @@ const BlogDetailPage: FC<BlogPageProps> = ({
 
 export default BlogDetailPage
 
-export const getStaticPaths = async context => {
-  const paths = await getBlogPaths(context.locales)
+export const getStaticPaths: GetStaticPaths = async context => {
+  const paths = await getBlogPaths(context.locales as StrapiLocale[])
 
   return {
     paths,
@@ -51,7 +48,7 @@ export const getStaticPaths = async context => {
   }
 }
 
-export const getStaticProps = async (context: GetStaticPropsContext) => {
+export const getStaticProps: GetStaticProps = async context => {
   const { blog, authorBlogs, seo, queryClient } = await getBlogStaticProps(
     context,
   )

--- a/apps/foundation/pages/club/art/[slug].tsx
+++ b/apps/foundation/pages/club/art/[slug].tsx
@@ -18,11 +18,9 @@ type ArtPageProps = {
 }
 
 const ArtPage: FC<ArtPageProps> = ({ seo, queryKey }) => {
-  // const auth = useAuth()
-
   return (
     <Layout seo={seo}>
-      <ArtTemplate auth={null} queryKey={queryKey} />
+      <ArtTemplate queryKey={queryKey} />
     </Layout>
   )
 }

--- a/apps/foundation/pages/club/artist/[username].tsx
+++ b/apps/foundation/pages/club/artist/[username].tsx
@@ -2,8 +2,9 @@ import { FC } from 'react'
 
 import { Avatar, SimpleGrid, Stack, Text } from '@chakra-ui/react'
 import { dehydrate } from '@tanstack/react-query'
+import { API_URL } from '@wsvvrijheid/config'
 import { StrapiLocale } from '@wsvvrijheid/types'
-import { ArtCard, Hero, useAuth, Container } from '@wsvvrijheid/ui'
+import { ArtCard, Hero, Container } from '@wsvvrijheid/ui'
 import {
   getArtistPaths,
   getArtistStaticProps,
@@ -25,18 +26,16 @@ const ArtistPage: FC<ArtistPageProps> = ({ seo }) => {
   const {
     query: { username },
   } = useRouter()
-  const auth = useAuth()
+
   const { data: artist, isLoading } = useArtistByUsername(username as string)
+
   return (
     <Layout seo={seo} isDark isLoading={isLoading} hasScroll>
       <Hero>
         <Stack align="center" cursor="default" userSelect="none">
           <Avatar
             size="lg"
-            src={
-              `${process.env.NEXT_PUBLIC_API_URL}${artist?.avatar?.formats.thumbnail.url}` ||
-              null
-            }
+            src={`${API_URL}${artist?.avatar?.formats.thumbnail.url}` || null}
             name={artist?.name || artist?.username}
           />
 
@@ -46,7 +45,7 @@ const ArtistPage: FC<ArtistPageProps> = ({ seo }) => {
       <Container mt={'80px'}>
         <SimpleGrid m={4} gap={8} columns={{ base: 1, md: 2, lg: 4 }}>
           {artist?.arts?.map(art => (
-            <ArtCard key={art.id} auth={auth} art={art} />
+            <ArtCard key={art.id} art={art} />
           ))}
         </SimpleGrid>
       </Container>

--- a/apps/foundation/pages/profile/index.tsx
+++ b/apps/foundation/pages/profile/index.tsx
@@ -1,50 +1,47 @@
-import React from 'react'
-
 import { AuthenticatedUserProfile, useAuth } from '@wsvvrijheid/ui'
-import { sessionOptions } from '@wsvvrijheid/utils'
-import { withIronSessionSsr } from 'iron-session/next'
+import { useAuthSelector } from '@wsvvrijheid/utils'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
 import { Layout } from '../../components'
 import i18nConfig from '../../next-i18next.config'
 
 const Profile = ({ seo }) => {
-  const auth = useAuth()
+  const { isLoggedIn } = useAuthSelector()
+  useAuth()
 
   return (
     <Layout seo={seo} isDark>
-      {auth.user && <AuthenticatedUserProfile auth={auth} />}
+      {isLoggedIn && <AuthenticatedUserProfile />}
     </Layout>
   )
 }
 
 export default Profile
 
-export const getServerSideProps = withIronSessionSsr(async function ({
-  req,
-  locale,
-}) {
-  const auth = req.session
+export const getStaticProps = async context => {
+  const { locale } = context
 
-  if (!auth.user) {
-    return {
-      redirect: {
-        permanent: false,
-        destination: '/login',
-      },
-      props: {},
-    }
+  const title = {
+    en: 'Profile',
+    tr: 'Profil',
+    nl: 'Profiel',
+  }
+
+  const description = {
+    en: '',
+    tr: '',
+    nl: '',
   }
 
   const seo = {
-    title: auth.user.username,
+    title: title[locale],
+    description: description[locale],
   }
 
   return {
     props: {
-      ...(await serverSideTranslations(locale, ['common'], i18nConfig)),
       seo,
+      ...(await serverSideTranslations(locale, ['common'], i18nConfig)),
     },
   }
-},
-sessionOptions)
+}

--- a/libs/ui/src/admin/ArtApprovalModal/ArtApprovalModal.tsx
+++ b/libs/ui/src/admin/ArtApprovalModal/ArtApprovalModal.tsx
@@ -126,7 +126,7 @@ export const ArtApprovalModal: FC<ArtApprovalTypes> = ({
                           value={description}
                         />
                         <Button
-                          colorScheme="green"
+                          colorScheme="primary"
                           onClick={() => handleSave('description')}
                           alignSelf="end"
                         >
@@ -157,7 +157,7 @@ export const ArtApprovalModal: FC<ArtApprovalTypes> = ({
                           value={content}
                         />
                         <Button
-                          colorScheme="green"
+                          colorScheme="primary"
                           onClick={() => handleSave('content')}
                           alignSelf="end"
                         >

--- a/libs/ui/src/admin/ArtApprovalModal/ArtFeedbackForm.tsx
+++ b/libs/ui/src/admin/ArtApprovalModal/ArtFeedbackForm.tsx
@@ -82,7 +82,7 @@ export const ArtFeedbackForm: FC<ArtFeedbackFormTypes> = ({
             <Button
               isDisabled={!feedback || artApprovalStatus === 'approved'}
               onClick={handleApprove}
-              colorScheme="green"
+              colorScheme="primary"
               w="full"
               leftIcon={<HiOutlineCheck />}
             >

--- a/libs/ui/src/admin/CreateCollectionModal/CreateCollectionModal.tsx
+++ b/libs/ui/src/admin/CreateCollectionModal/CreateCollectionModal.tsx
@@ -22,7 +22,7 @@ import slugify from '@sindresorhus/slugify'
 import { CollectionCreateInput } from '@wsvvrijheid/types'
 import { useCreateCollection } from '@wsvvrijheid/utils'
 import { useForm } from 'react-hook-form'
-import { FaCheck, FaTimes, FaPlus } from 'react-icons/fa'
+import { IoMdAdd, IoMdCheckmark, IoMdClose } from 'react-icons/io'
 import * as yup from 'yup'
 
 import { FormItem, FilePicker } from '../../components'
@@ -117,14 +117,11 @@ export const CreateCollectionModal: FC<CreateCollectionModalProps> = ({
       />
 
       <Button
-        size="lg"
-        colorScheme="green"
+        leftIcon={<IoMdAdd />}
+        colorScheme="primary"
         onClick={formDisclosure.onOpen}
         my={3}
       >
-        <Box mr={{ base: 0, lg: 4 }}>
-          <FaPlus />
-        </Box>
         <Box display={{ base: 'none', lg: 'block' }}>Create Collection</Box>
       </Button>
 
@@ -137,8 +134,8 @@ export const CreateCollectionModal: FC<CreateCollectionModalProps> = ({
       >
         <ModalOverlay />
         <ModalContent>
-          <ModalHeader color={'green'}>Create Collection</ModalHeader>
-          <ModalCloseButton color={'white'} />
+          <ModalHeader color={'primary.500'}>Create Collection</ModalHeader>
+          <ModalCloseButton />
           <ModalBody pos="relative" py={6}>
             {/* LOADING */}
             {isLoading && (
@@ -181,15 +178,15 @@ export const CreateCollectionModal: FC<CreateCollectionModalProps> = ({
                   onClick={closeForm}
                   mr={3}
                   ref={cancelRef}
-                  leftIcon={<FaTimes />}
+                  leftIcon={<IoMdClose />}
                 >
                   Cancel
                 </Button>
                 <Button
                   isDisabled={!images || images.length === 0 || !isValid}
                   type="submit"
-                  colorScheme="green"
-                  leftIcon={<FaCheck />}
+                  colorScheme="primary"
+                  leftIcon={<IoMdCheckmark />}
                 >
                   Create Collection
                 </Button>

--- a/libs/ui/src/admin/CreateCollectionModal/CreateCollectionSuccessAlert.tsx
+++ b/libs/ui/src/admin/CreateCollectionModal/CreateCollectionSuccessAlert.tsx
@@ -29,7 +29,7 @@ export const CollectionCreateSuccessAlert = forwardRef<
       <AlertDialogOverlay>
         <AlertDialogContent>
           <AlertDialogHeader
-            bg="green.500"
+            bg="primary.500"
             color="white"
             fontSize="lg"
             fontWeight="semibold"

--- a/libs/ui/src/admin/DataTables/ArtsTable/ArtsTable.tsx
+++ b/libs/ui/src/admin/DataTables/ArtsTable/ArtsTable.tsx
@@ -2,9 +2,10 @@ import { FC, useState } from 'react'
 
 import { useDisclosure } from '@chakra-ui/react'
 import { QueryKey } from '@tanstack/react-query'
-import { Art, SessionUser, UploadFile } from '@wsvvrijheid/types'
+import { Art, UploadFile } from '@wsvvrijheid/types'
 import {
   useArtFeedbackMutation,
+  useAuthSelector,
   useDeleteArt,
   usePublishModel,
   useUnpublishModel,
@@ -18,19 +19,18 @@ import { DataTableProps } from '../types'
 import { columns } from './columns'
 
 type ArtsTableProps = Omit<DataTableProps<Art>, 'columns'> & {
-  user: SessionUser
   queryKey?: QueryKey
 }
 
 export const ArtsTable: FC<ArtsTableProps> = ({
   queryKey,
   data: arts,
-  user,
   totalCount,
   currentPage,
   onSort,
   setCurrentPage,
 }) => {
+  const { user } = useAuthSelector()
   const approvalDisclosure = useDisclosure()
   const confirmDisclosure = useDisclosure()
   const [selectedIndex, setSelectedIndex] = useState<number>()

--- a/libs/ui/src/admin/Layout/AdminLayout.tsx
+++ b/libs/ui/src/admin/Layout/AdminLayout.tsx
@@ -10,7 +10,7 @@ import {
   Stack,
   useBoolean,
 } from '@chakra-ui/react'
-import { SessionUser } from '@wsvvrijheid/types'
+import { useAuthSelector } from '@wsvvrijheid/utils'
 import axios from 'axios'
 import { NextSeo } from 'next-seo'
 import { useRouter } from 'next/router'
@@ -22,19 +22,17 @@ import { PageHeader, PageHeaderProps } from '../PageHeader'
 
 export type AdminLayoutProps = {
   children: ReactNode
-  isLoading?: boolean
   title: string
-  user: SessionUser
   headerProps?: PageHeaderProps
 }
 
 export const AdminLayout: FC<AdminLayoutProps> = ({
   children,
-  isLoading,
   title,
-  user,
   headerProps,
 }) => {
+  const { user, isAuthLoading } = useAuthSelector()
+
   const [expandedStorage, setExpandedStorage] = useLocalStorage(
     'adminSidebarExpanded',
     true,
@@ -55,7 +53,7 @@ export const AdminLayout: FC<AdminLayoutProps> = ({
   }
 
   // Loading indicator when we are fetching user data on the client
-  if (isLoading) {
+  if (isAuthLoading || !user) {
     return (
       <>
         <NextSeo title={title} />

--- a/libs/ui/src/admin/LocaleBadges/LocaleBadges.tsx
+++ b/libs/ui/src/admin/LocaleBadges/LocaleBadges.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import { FC } from 'react'
 
 import { Badge, BadgeProps, HStack } from '@chakra-ui/react'
 import { StrapiLocale } from '@wsvvrijheid/types'

--- a/libs/ui/src/admin/PublicationBadges/PublicationBadges.tsx
+++ b/libs/ui/src/admin/PublicationBadges/PublicationBadges.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import { FC } from 'react'
 
 import { Badge, BadgeProps } from '@chakra-ui/react'
 

--- a/libs/ui/src/components/ArtCard/ArtCard.tsx
+++ b/libs/ui/src/components/ArtCard/ArtCard.tsx
@@ -1,24 +1,23 @@
 import { FC } from 'react'
 
-import { useLikeArt } from '@wsvvrijheid/utils'
+import { useAuthSelector, useLikeArt } from '@wsvvrijheid/utils'
 
 import { ArtCardBase, ArtCardProps } from '../'
 
 export const ArtCard: FC<ArtCardProps> = ({
   art,
-  auth,
   queryKey,
   actionQueryKey,
 }) => {
-  const { toggleLike, isLiked } = useLikeArt(art, auth.user, queryKey)
+  const { toggleLike, isLiked } = useLikeArt(art, queryKey)
+  const { user } = useAuthSelector()
 
   return (
     <ArtCardBase
-      auth={auth}
       art={art}
       isLiked={isLiked as boolean}
       toggleLike={toggleLike}
-      isOwner={auth.user?.id === art.artist?.id}
+      isOwner={user?.id === art.artist?.id}
       isMasonry
       isModal
       actionQueryKey={actionQueryKey}

--- a/libs/ui/src/components/ArtCard/ArtCardBase.stories.tsx
+++ b/libs/ui/src/components/ArtCard/ArtCardBase.stories.tsx
@@ -42,7 +42,7 @@ const Template: ComponentStory<typeof ArtCardBase> = args => {
     publish: {
       title: 'Publish',
       buttonText: 'Publish',
-      colorScheme: 'green',
+      colorScheme: 'primary',
       text: 'Are you sure you want to publish this art?',
       onClick: () => alert('Published'),
     },

--- a/libs/ui/src/components/ArtCard/ArtCardBase.tsx
+++ b/libs/ui/src/components/ArtCard/ArtCardBase.tsx
@@ -29,7 +29,6 @@ import { ArtCardImage } from './ArtCardImage'
 import { ArtActionType, ArtCardBaseProps } from './types'
 
 export const ArtCardBase: FC<ArtCardBaseProps> = ({
-  auth,
   art,
   isMasonry,
   toggleLike,
@@ -227,7 +226,6 @@ export const ArtCardBase: FC<ArtCardBaseProps> = ({
             </Navigate>
           </Stack>
           <ArtModal
-            auth={auth}
             art={art}
             isOpen={artModalIsOpen}
             onClose={artModalOnClose}

--- a/libs/ui/src/components/ArtCard/types.ts
+++ b/libs/ui/src/components/ArtCard/types.ts
@@ -2,7 +2,7 @@ import { ComponentProps } from 'react'
 
 import { Button } from '@chakra-ui/react'
 import { QueryKey } from '@tanstack/react-query'
-import { Art, Auth, UploadFile } from '@wsvvrijheid/types'
+import { Art, UploadFile } from '@wsvvrijheid/types'
 
 export type ArtActionType = 'delete' | 'publish' | 'unpublish'
 
@@ -17,14 +17,12 @@ export type ArtActionContext = {
 export type ArtActions = Record<ArtActionType, ArtActionContext>
 
 export type ArtCardProps = {
-  auth: Auth
   art: Art
   queryKey?: QueryKey
   actionQueryKey?: QueryKey
 }
 
 export type ArtCardBaseProps = {
-  auth: Auth
   actions?: ArtActions
   art: Art
   isLiked?: boolean

--- a/libs/ui/src/components/ArtModal/ArtModal.stories.tsx
+++ b/libs/ui/src/components/ArtModal/ArtModal.stories.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, useDisclosure } from '@chakra-ui/react'
 import { Meta, Story } from '@storybook/react'
-import { ART_MOCKS, USER_MOCKS } from '@wsvvrijheid/mocks'
+import { ART_MOCKS } from '@wsvvrijheid/mocks'
 import { sample } from 'lodash'
 
 import { ArtModal, ArtModalProps } from './ArtModal'
@@ -31,12 +31,3 @@ const Template: Story<ArtModalProps> = args => {
 
 export const Default = Template.bind({})
 Default.args = {}
-
-export const Auth = Template.bind({})
-Auth.args = {
-  auth: {
-    isLoggedIn: true,
-    user: sample(USER_MOCKS),
-    token: 'mock-token',
-  },
-}

--- a/libs/ui/src/components/ArtModal/ArtModal.tsx
+++ b/libs/ui/src/components/ArtModal/ArtModal.tsx
@@ -9,18 +9,17 @@ import {
   ModalOverlay,
   Box,
 } from '@chakra-ui/react'
-import { Art, Auth } from '@wsvvrijheid/types'
+import { Art } from '@wsvvrijheid/types'
 
 import { ArtWithDetails } from '../ArtWithDetails'
 
 export type ArtModalProps = {
-  auth: Auth
   art: Art
   isOpen: boolean
   onClose: () => void
 }
 
-export const ArtModal: FC<ArtModalProps> = ({ auth, art, isOpen, onClose }) => {
+export const ArtModal: FC<ArtModalProps> = ({ art, isOpen, onClose }) => {
   return (
     <Box>
       <Modal onClose={onClose} isOpen={isOpen} scrollBehavior="inside">
@@ -28,7 +27,7 @@ export const ArtModal: FC<ArtModalProps> = ({ auth, art, isOpen, onClose }) => {
         <ModalContent maxW="95vw" h="full" p={{ base: 2, lg: 4 }}>
           <ModalCloseButton />
           <ModalBody>
-            <ArtWithDetails auth={auth} art={art} />
+            <ArtWithDetails art={art} />
           </ModalBody>
         </ModalContent>
       </Modal>

--- a/libs/ui/src/components/ArtWithDetails/ArtWithDetails.tsx
+++ b/libs/ui/src/components/ArtWithDetails/ArtWithDetails.tsx
@@ -3,10 +3,11 @@ import { FC } from 'react'
 import '@splidejs/splide/dist/css/themes/splide-default.min.css'
 import { Stack, Box, Grid } from '@chakra-ui/react'
 import { QueryKey, useQueryClient } from '@tanstack/react-query'
-import { Art, Auth } from '@wsvvrijheid/types'
+import { Art } from '@wsvvrijheid/types'
 import {
   useArtBySlug,
   useArtCommentMutation,
+  useAuthSelector,
   useLikeArt,
 } from '@wsvvrijheid/utils'
 
@@ -19,22 +20,15 @@ import {
 import { CommentFormFieldValues } from '../CommentForm/types'
 
 export type ArtWithDetailsProps = {
-  auth: Auth
   art: Art
   queryKey?: QueryKey
 }
 
-export const ArtWithDetails: FC<ArtWithDetailsProps> = ({
-  auth,
-  art,
-  queryKey,
-}) => {
-  const { toggleLike, isLiked, isLoading } = useLikeArt(
-    art,
-    auth?.user,
-    queryKey,
-  )
+export const ArtWithDetails: FC<ArtWithDetailsProps> = ({ art, queryKey }) => {
+  const { toggleLike, isLiked, isLoading } = useLikeArt(art, queryKey)
   const queryClient = useQueryClient()
+
+  const auth = useAuthSelector()
 
   const artCommentMutation = useArtCommentMutation()
   const { data } = useArtBySlug(art.slug)
@@ -95,7 +89,6 @@ export const ArtWithDetails: FC<ArtWithDetailsProps> = ({
         <Stack spacing={4}>
           {/*  Comment form */}
           <CommentForm
-            auth={auth}
             isLoading={artCommentMutation.isLoading}
             onSendForm={handleSendForm}
             isSuccess={artCommentMutation.isSuccess}

--- a/libs/ui/src/components/CommentForm/CommentForm.tsx
+++ b/libs/ui/src/components/CommentForm/CommentForm.tsx
@@ -12,6 +12,7 @@ import {
   VStack,
 } from '@chakra-ui/react'
 import { yupResolver } from '@hookform/resolvers/yup'
+import { useAuthSelector } from '@wsvvrijheid/utils'
 import { useTranslation } from 'next-i18next'
 import { useForm } from 'react-hook-form'
 import { TFunction } from 'react-i18next'
@@ -37,12 +38,12 @@ const publicSchema = (t: TFunction) =>
   })
 
 export const CommentForm: React.FC<CommentFormProps> = ({
-  auth,
   onSendForm,
   isLoading,
   isSuccess,
 }) => {
   const { t } = useTranslation()
+  const { user, isLoggedIn } = useAuthSelector()
 
   const {
     register,
@@ -50,7 +51,7 @@ export const CommentForm: React.FC<CommentFormProps> = ({
     reset,
     formState: { errors, isValid },
   } = useForm<CommentFormFieldValues>({
-    resolver: yupResolver(auth?.isLoggedIn ? userSchema(t) : publicSchema(t)),
+    resolver: yupResolver(isLoggedIn ? userSchema(t) : publicSchema(t)),
     mode: 'all',
   })
 
@@ -75,7 +76,7 @@ export const CommentForm: React.FC<CommentFormProps> = ({
         justify="flex-start"
       >
         <Stack w="100%" alignItems="flex-start">
-          {!auth?.isLoggedIn && (
+          {!isLoggedIn && (
             <Stack direction={{ base: 'column', lg: 'row' }} w="full">
               <FormItem
                 name="name"
@@ -95,12 +96,8 @@ export const CommentForm: React.FC<CommentFormProps> = ({
             </Stack>
           )}
           <HStack w="full" align="start">
-            {auth?.isLoggedIn && (
-              <Avatar
-                size="sm"
-                src={`${auth.user?.avatar}`}
-                name={auth.user?.username}
-              />
+            {isLoggedIn && (
+              <Avatar size="sm" src={`${user?.avatar}`} name={user?.username} />
             )}
             <FormItem
               as={Textarea}

--- a/libs/ui/src/components/CommentForm/types.ts
+++ b/libs/ui/src/components/CommentForm/types.ts
@@ -1,5 +1,3 @@
-import { Auth } from '@wsvvrijheid/types'
-
 export type CommentFormFieldValues = {
   email?: string
   name?: string
@@ -8,7 +6,6 @@ export type CommentFormFieldValues = {
 
 export type CommentFormProps = {
   errorMessage?: string
-  auth?: Auth
   isLoading: boolean
   isSuccess: boolean
   onSendForm: (data: CommentFormFieldValues) => void

--- a/libs/ui/src/components/CreateArtForm/CreateArtForm.tsx
+++ b/libs/ui/src/components/CreateArtForm/CreateArtForm.tsx
@@ -26,7 +26,11 @@ import {
 import { yupResolver } from '@hookform/resolvers/yup'
 import slugify from '@sindresorhus/slugify'
 import { StrapiLocale } from '@wsvvrijheid/types'
-import { useCreateArt, useGetArtCategories } from '@wsvvrijheid/utils'
+import {
+  useAuthSelector,
+  useCreateArt,
+  useGetArtCategories,
+} from '@wsvvrijheid/utils'
 import { useTranslation } from 'next-i18next'
 import { useRouter } from 'next/router'
 import { useForm } from 'react-hook-form'
@@ -56,11 +60,13 @@ const schema = (t: TFunction) =>
   })
 
 // TODO Consider adding modal form instead of a new page
-export const CreateArtForm: FC<CreateArtFormProps> = ({ auth, queryKey }) => {
+export const CreateArtForm: FC<CreateArtFormProps> = ({ queryKey }) => {
   const [images, setImages] = useState<Blob[]>([])
   const { locale } = useRouter()
   const { t } = useTranslation()
   const categories = useGetArtCategories()
+
+  const auth = useAuthSelector()
 
   const cancelRef = useRef<HTMLButtonElement>(null)
   const formDisclosure = useDisclosure()

--- a/libs/ui/src/components/CreateArtForm/CreateArtSuccessAlert.tsx
+++ b/libs/ui/src/components/CreateArtForm/CreateArtSuccessAlert.tsx
@@ -32,7 +32,7 @@ export const ArtCreateSuccessAlert = forwardRef<
       <AlertDialogOverlay>
         <AlertDialogContent>
           <AlertDialogHeader
-            bg="green.500"
+            bg="primary.500"
             color="white"
             fontSize="lg"
             fontWeight="semibold"

--- a/libs/ui/src/components/CreateArtForm/types.ts
+++ b/libs/ui/src/components/CreateArtForm/types.ts
@@ -1,5 +1,5 @@
 import { QueryKey } from '@tanstack/react-query'
-import { Auth, StrapiLocale } from '@wsvvrijheid/types'
+import { StrapiLocale } from '@wsvvrijheid/types'
 
 export type CreateArtFormFieldValues = {
   locale: StrapiLocale
@@ -13,7 +13,6 @@ export type CreateArtFormFieldValues = {
 }
 
 export type CreateArtFormProps = {
-  auth: Auth
   queryKey?: QueryKey
 }
 

--- a/libs/ui/src/components/CreateTweetForm/CreateTweetForm.tsx
+++ b/libs/ui/src/components/CreateTweetForm/CreateTweetForm.tsx
@@ -59,7 +59,7 @@ export const CreateTweetForm: React.FC<CreateTweetFormProps> = ({
         <ModalContent maxW="95vw" h="full" p={{ base: 2, lg: 8 }}>
           <ModalCloseButton />
           <ModalHeader>
-            <Text color={'green.500'} fontWeight={'bold'} w={'full'}>
+            <Text color={'primary.500'} fontWeight={'bold'} w={'full'}>
               Create Tweet
             </Text>
           </ModalHeader>
@@ -133,7 +133,7 @@ export const CreateTweetForm: React.FC<CreateTweetFormProps> = ({
                   </Button>
                   <Button
                     type="submit"
-                    colorScheme="green"
+                    colorScheme="primary"
                     leftIcon={<FiArrowUpRight />}
                     onClick={onSubmitHandler}
                   >

--- a/libs/ui/src/components/LoginForm/LoginForm.tsx
+++ b/libs/ui/src/components/LoginForm/LoginForm.tsx
@@ -10,6 +10,7 @@ import {
 } from '@chakra-ui/react'
 import { yupResolver } from '@hookform/resolvers/yup'
 import { useMutation } from '@tanstack/react-query'
+import { checkAuth, useAppDispatch } from '@wsvvrijheid/utils'
 import axios from 'axios'
 import { useTranslation } from 'next-i18next'
 import { useRouter } from 'next/router'
@@ -54,6 +55,8 @@ export const LoginForm = () => {
     mode: 'all',
   })
 
+  const dispatch = useAppDispatch()
+
   const router = useRouter()
   useAuth('/profile', true)
 
@@ -63,6 +66,7 @@ export const LoginForm = () => {
       axios.post('/api/auth/login', body),
     onSuccess: () => {
       reset()
+      dispatch(checkAuth())
       router.push('/')
     },
   })

--- a/libs/ui/src/components/Profile/Profile.tsx
+++ b/libs/ui/src/components/Profile/Profile.tsx
@@ -1,5 +1,3 @@
-import { FC } from 'react'
-
 import {
   Avatar,
   Box,
@@ -14,8 +12,7 @@ import {
   Text,
 } from '@chakra-ui/react'
 import { API_URL } from '@wsvvrijheid/config'
-import { Auth, SessionUser } from '@wsvvrijheid/types'
-import { useArtByArtist } from '@wsvvrijheid/utils'
+import { useArtByArtist, useAuthSelector } from '@wsvvrijheid/utils'
 import { useTranslation } from 'next-i18next'
 import { FaPaintBrush, FaSpinner } from 'react-icons/fa'
 import { IoMdSettings } from 'react-icons/io'
@@ -26,19 +23,10 @@ import { Container } from '../Container'
 import { CreateArtForm } from '../CreateArtForm'
 import { Hero } from '../Hero'
 
-export type AuthenticatedUserProfileProps = {
-  auth: Auth
-}
-export type SettingsProps = {
-  user: SessionUser | null
-}
-
-export const AuthenticatedUserProfile: FC<AuthenticatedUserProfileProps> = ({
-  auth,
-}) => {
+export const AuthenticatedUserProfile = () => {
   const { t } = useTranslation()
 
-  const { user } = auth
+  const { user } = useAuthSelector()
 
   const { data } = useArtByArtist(user?.username)
   const rejected = data?.filter(art => art?.approvalStatus === 'rejected')
@@ -86,7 +74,7 @@ export const AuthenticatedUserProfile: FC<AuthenticatedUserProfileProps> = ({
                 <Box as={IoMdSettings} mr={1} /> {t`profile.general-settings`}
               </Tab>
               <Box my={1} ml={2}>
-                <CreateArtForm auth={auth} queryKey={['user-art']} />
+                <CreateArtForm queryKey={['user-art']} />
               </Box>
             </TabList>
           </Box>
@@ -97,7 +85,6 @@ export const AuthenticatedUserProfile: FC<AuthenticatedUserProfileProps> = ({
                 {approved?.map(art => (
                   <ArtCard
                     key={art.id}
-                    auth={auth}
                     art={art}
                     actionQueryKey={['user-art']}
                   />
@@ -111,7 +98,6 @@ export const AuthenticatedUserProfile: FC<AuthenticatedUserProfileProps> = ({
                   return (
                     <ArtCard
                       key={art.id}
-                      auth={auth}
                       art={art}
                       actionQueryKey={['user-art']}
                     />
@@ -126,7 +112,6 @@ export const AuthenticatedUserProfile: FC<AuthenticatedUserProfileProps> = ({
                   return (
                     <ArtCard
                       key={art.id}
-                      auth={auth}
                       art={art}
                       actionQueryKey={['user-art']}
                     />
@@ -136,7 +121,7 @@ export const AuthenticatedUserProfile: FC<AuthenticatedUserProfileProps> = ({
             </TabPanel>
             {/* general Settings */}
             <TabPanel>
-              <Settings user={user} />
+              <Settings />
             </TabPanel>
           </TabPanels>
         </Tabs>
@@ -145,7 +130,9 @@ export const AuthenticatedUserProfile: FC<AuthenticatedUserProfileProps> = ({
   )
 }
 
-export const Settings: FC<SettingsProps> = ({ user }) => {
+export const Settings = () => {
+  const { user } = useAuthSelector()
+
   return (
     <Stack>
       <Text>Username: {user?.username}</Text>

--- a/libs/ui/src/components/WTable/WTable.stories.tsx
+++ b/libs/ui/src/components/WTable/WTable.stories.tsx
@@ -72,7 +72,7 @@ Arts.args = {
       // Custom props based on value
       componentProps: value => {
         const colorScheme = {
-          approved: 'green',
+          approved: 'primary',
           pending: 'yellow',
           rejected: 'red',
         }

--- a/libs/ui/src/hooks/useAuth.tsx
+++ b/libs/ui/src/hooks/useAuth.tsx
@@ -1,38 +1,31 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect } from 'react'
 
-import { useQuery } from '@tanstack/react-query'
 import { Auth } from '@wsvvrijheid/types'
-import axios from 'axios'
+import { useAuthSelector } from '@wsvvrijheid/utils'
 import Router from 'next/router'
 
 export const useAuth = (
   redirectTo?: string,
   redirectIfFound = false,
-): Auth & { isLoading: boolean } => {
-  const { data, isLoading, isSuccess } = useQuery(['me'], () =>
-    axios('/api/auth/user'),
-  )
-
-  const auth = useMemo(
-    () => data?.data || { user: null, isLoggedIn: false, token: null },
-    [data],
-  ) as Auth
+): Auth & { isAuthLoading: boolean } => {
+  const { user, isAuthLoading, token, isLoggedIn } = useAuthSelector()
 
   useEffect(() => {
+    if (user) return
     // if no redirect needed, just return (example: already on /dashboard)
     // if user data not yet there (fetch in progress, logged in or not) then don't do anything yet
 
-    if (!isLoading && isSuccess && redirectTo) {
+    if (token && redirectTo) {
       if (
         // If redirectTo is set, redirect if the user was not found.
-        (!redirectIfFound && !auth?.isLoggedIn) ||
+        (!redirectIfFound && !isAuthLoading) ||
         // If redirectIfFound is also set, redirect if the user was found
-        (redirectIfFound && auth.isLoggedIn)
+        (redirectIfFound && isAuthLoading)
       ) {
         Router.push(redirectTo)
       }
     }
-  }, [auth, redirectIfFound, redirectTo, isLoading, isSuccess])
+  }, [isLoggedIn, isAuthLoading, token])
 
-  return { ...auth, isLoading }
+  return { user, token, isLoggedIn, isAuthLoading }
 }

--- a/libs/ui/src/templates/ArtClubTemplate/ArtClubTemplate.tsx
+++ b/libs/ui/src/templates/ArtClubTemplate/ArtClubTemplate.tsx
@@ -32,7 +32,7 @@ import {
   Pagination,
   ArtCard,
 } from '../../components'
-import { useAuth, useChangeParams } from '../../hooks'
+import { useChangeParams } from '../../hooks'
 
 export const ArtClubTemplate: FC = () => {
   const {
@@ -41,7 +41,6 @@ export const ArtClubTemplate: FC = () => {
   } = useRouter()
 
   const changeParam = useChangeParams()
-  const auth = useAuth()
   const [isLoading, setIsLoading] = useState(false)
   const { isOpen, onOpen, onClose } = useDisclosure()
   const { t } = useTranslation()
@@ -115,7 +114,7 @@ export const ArtClubTemplate: FC = () => {
                 onSearch={value => changeParam({ searchTerm: value as string })}
                 isFetching={artsQuery.isFetching}
               />
-              <CreateArtForm auth={auth} />
+              <CreateArtForm />
               <IconButton
                 display={{ base: 'flex', lg: 'none' }}
                 variant="outline"
@@ -143,7 +142,7 @@ export const ArtClubTemplate: FC = () => {
                         directing="to-down"
                         delay={i * 0.5}
                       >
-                        <ArtCard art={art} auth={auth} queryKey={queryKey} />
+                        <ArtCard art={art} queryKey={queryKey} />
                       </AnimatedBox>
                     )
                   })}

--- a/libs/ui/src/templates/ArtTemplate/ArtTemplate.stories.tsx
+++ b/libs/ui/src/templates/ArtTemplate/ArtTemplate.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, Story } from '@storybook/react'
-import { ART_MOCKS, USER_MOCKS } from '@wsvvrijheid/mocks'
+import { ART_MOCKS } from '@wsvvrijheid/mocks'
 import { sample } from 'lodash'
 
 import { ArtTemplate, ArtTemplateProps } from './ArtTemplate'
@@ -27,12 +27,3 @@ const Template: Story<ArtTemplateProps> = args => {
 
 export const Default = Template.bind({})
 Default.args = {} as ArtTemplateProps
-
-export const Auth = Template.bind({})
-Auth.args = {
-  auth: {
-    isLoggedIn: true,
-    user: sample(USER_MOCKS),
-    token: 'mock-token',
-  },
-} as ArtTemplateProps

--- a/libs/ui/src/templates/ArtTemplate/ArtTemplate.tsx
+++ b/libs/ui/src/templates/ArtTemplate/ArtTemplate.tsx
@@ -3,7 +3,6 @@ import { FC } from 'react'
 import { Heading, Stack, useBreakpointValue } from '@chakra-ui/react'
 import { Splide, SplideSlide } from '@splidejs/react-splide'
 import { QueryKey } from '@tanstack/react-query'
-import { Auth } from '@wsvvrijheid/types'
 import {
   useArtBySlug,
   useArtsByCategories,
@@ -14,11 +13,10 @@ import { useTranslation } from 'react-i18next'
 import { Container, ArtCardBase, ArtWithDetails } from '../../components'
 
 export type ArtTemplateProps = {
-  auth: Auth
   queryKey: QueryKey
 }
 
-export const ArtTemplate: FC<ArtTemplateProps> = ({ auth, queryKey }) => {
+export const ArtTemplate: FC<ArtTemplateProps> = ({ queryKey }) => {
   const { t } = useTranslation()
   const perPage = useBreakpointValue({ base: 1, sm: 2, md: 3, lg: 4 })
   const { data: art } = useArtBySlug()
@@ -36,7 +34,7 @@ export const ArtTemplate: FC<ArtTemplateProps> = ({ auth, queryKey }) => {
     <Container minH="inherit" my={8}>
       {/* TODO Create skeleton components for ArtDetail ArtContent and Comments */}
 
-      <ArtWithDetails auth={auth} art={art} queryKey={queryKey} />
+      <ArtWithDetails art={art} queryKey={queryKey} />
 
       {/* Other Arts List */}
       {arts && arts?.length > 0 && (
@@ -53,12 +51,7 @@ export const ArtTemplate: FC<ArtTemplateProps> = ({ auth, queryKey }) => {
           >
             {arts.map(art => (
               <SplideSlide key={art.id}>
-                <ArtCardBase
-                  auth={auth}
-                  art={art}
-                  isLiked={false}
-                  isOwner={false}
-                />
+                <ArtCardBase art={art} isLiked={false} isOwner={false} />
               </SplideSlide>
             ))}
           </Splide>

--- a/libs/ui/src/templates/BlogTemplate/BlogDetailTemplate.tsx
+++ b/libs/ui/src/templates/BlogTemplate/BlogDetailTemplate.tsx
@@ -3,7 +3,7 @@ import { FC } from 'react'
 
 import { QueryKey } from '@tanstack/react-query'
 import { SITE_URL } from '@wsvvrijheid/config'
-import { Auth, Blog } from '@wsvvrijheid/types'
+import { Blog } from '@wsvvrijheid/types'
 import { useGetBlog, useLikeBlog, useViewBlog } from '@wsvvrijheid/utils'
 import { MDXRemoteSerializeResult } from 'next-mdx-remote'
 import { useRouter } from 'next/router'
@@ -12,14 +12,12 @@ import { Container } from '../../components'
 import { BlogDetail } from '../../components/BlogDetail'
 
 export type BlogDetailTemplateProps = {
-  auth: Auth
   queryKey: QueryKey
   authorBlogs: Blog[]
   source: MDXRemoteSerializeResult
 }
 
 export const BlogDetailTemplate: FC<BlogDetailTemplateProps> = ({
-  auth,
   queryKey,
   source,
   authorBlogs,
@@ -32,7 +30,7 @@ export const BlogDetailTemplate: FC<BlogDetailTemplateProps> = ({
   if (!source) return null
   const { data: blog } = useGetBlog(slug as string)
   if (!blog) return null
-  const { isLiked, toggleLike } = useLikeBlog(blog, auth?.user, queryKey)
+  const { isLiked, toggleLike } = useLikeBlog(blog, queryKey)
 
   const link = `${SITE_URL}/${locale}/blog/${slug}`
 

--- a/libs/utils/src/services/art/like.ts
+++ b/libs/utils/src/services/art/like.ts
@@ -1,8 +1,9 @@
 import { QueryKey, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Art, ArtUpdateInput, SessionUser } from '@wsvvrijheid/types'
+import { Art, ArtUpdateInput } from '@wsvvrijheid/types'
 import { useLocalStorage } from 'react-use'
 
 import { Mutation } from '../../lib'
+import { useAuthSelector } from '../../store'
 
 type LikersMutationArgs = {
   id: number
@@ -40,12 +41,10 @@ const useLikeArtPublicMutation = () => {
   })
 }
 
-export const useLikeArt = (
-  art?: Art | null,
-  user?: SessionUser | null,
-  queryKey?: QueryKey,
-) => {
+export const useLikeArt = (art?: Art | null, queryKey?: QueryKey) => {
   const queryClient = useQueryClient()
+
+  const { user } = useAuthSelector()
 
   const likeArtByUserMutation = useLikeArtByUserMutation()
   const likeArtPublicMutation = useLikeArtPublicMutation()

--- a/libs/utils/src/services/blog/like.ts
+++ b/libs/utils/src/services/blog/like.ts
@@ -3,6 +3,7 @@ import { Blog, BlogUpdateInput, SessionUser } from '@wsvvrijheid/types'
 import { useLocalStorage } from 'react-use'
 
 import { Mutation } from '../../lib'
+import { useAuthSelector } from '../../store'
 
 type LikersMutationArgs = {
   id: number
@@ -43,12 +44,10 @@ const useLikeBlogPublicMutation = () => {
   })
 }
 
-export const useLikeBlog = (
-  blog?: Blog | null,
-  user?: SessionUser | null,
-  queryKey?: QueryKey,
-) => {
+export const useLikeBlog = (blog?: Blog | null, queryKey?: QueryKey) => {
   const queryClient = useQueryClient()
+
+  const { user } = useAuthSelector()
 
   const likeBlogByUserMutation = useLikeBlogByUserMutation()
   const likeBlogPublicMutation = useLikeBlogPublicMutation()

--- a/libs/utils/src/store/auth.ts
+++ b/libs/utils/src/store/auth.ts
@@ -1,0 +1,49 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
+import { Auth, SessionUser } from '@wsvvrijheid/types'
+import axios from 'axios'
+
+export type AuthState = {
+  user: SessionUser | null
+  isAuthLoading: boolean
+  token: string | null
+  isLoggedIn: boolean
+}
+
+const initialState: AuthState = {
+  user: null,
+  isAuthLoading: true,
+  token: null,
+  isLoggedIn: false,
+}
+
+export const checkAuth = createAsyncThunk('auth/check', async () => {
+  const response = await axios.get<Auth>('/api/auth/user')
+  return response.data
+})
+
+export const destroyAuth = createAsyncThunk('auth/destroy', async () => {
+  await axios.get<Auth>('/api/auth/logout')
+  return initialState
+})
+
+export const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder.addCase(checkAuth.fulfilled, (state, action) => {
+      state.user = action.payload.user
+      state.isAuthLoading = false
+      state.token = action.payload.token
+      state.isLoggedIn = true
+    })
+    builder.addCase(checkAuth.pending, (state, action) => {
+      state.isAuthLoading = true
+    })
+    builder.addCase(destroyAuth.fulfilled, state => {
+      state = initialState
+    })
+  },
+})
+
+export const { reducer: authReducer } = authSlice

--- a/libs/utils/src/store/index.ts
+++ b/libs/utils/src/store/index.ts
@@ -1,2 +1,3 @@
+export * from './auth'
 export * from './post'
 export * from './store'

--- a/libs/utils/src/store/store.ts
+++ b/libs/utils/src/store/store.ts
@@ -1,11 +1,13 @@
 import { Action, configureStore, ThunkAction } from '@reduxjs/toolkit'
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
 
+import { authReducer } from './auth'
 import { postReducer } from './post'
 
 export const store = configureStore({
   reducer: {
     post: postReducer,
+    auth: authReducer,
   },
 })
 
@@ -21,3 +23,4 @@ export type AppThunk<ReturnType = void> = ThunkAction<
 export const useAppDispatch = () => useDispatch<AppDispatch>()
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
 export const usePostSelector = () => useAppSelector(state => state.post)
+export const useAuthSelector = () => useAppSelector(state => state.auth)


### PR DESCRIPTION
> Node.js stateless session utility using signed and encrypted cookies to store data. Works with Next.js, Express, and Node.js HTTP servers.
> The session data is stored in encrypted cookies ("seals"). And only your server can decode the session data. There are no session ids, making iron sessions "stateless" from the server point of view.
> This strategy of storing session data is the same technique used by frameworks like [Ruby On Rails](https://guides.rubyonrails.org/security.html#session-storage) (their default strategy).

Ref: https://github.com/vvo/iron-session

___

### Info

We had implemented iron-session for our authentication process. 

This PR may appear to be meaningless since the idea behind iron-session is to have a **stateless session**. But in this case we save some sensitive data in redux store (user and token). It's less secure but easy to manage the authentication data.

You can reach auth data from any component by calling auth selector.

```ts
// const { user, token, isLoading, isLoggedIn } = useAppSelector(state => state.auth)
const { user, token, isLoading, isLoggedIn } = useAuthSelector()
```

### Storybook

We usually test our components via props. Typically, we use props to test our components. Even though Redux makes it simpler, I still do not advise using auth store in **all minor components**.

### Improvements

We shouldn't ship `post-reducer` to our apps other than `PostMaker (samenvvv)`. Because `post-reducer` will only be using in PostMaker components. We can create separate store for it.
