### PR TITLE
Update user stats backend

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,7 +13,9 @@
     "docker-up": "docker compose up --remove-orphans",
     "docker-db": "docker exec -i strapiDB bash < ./scripts/docker-db-update.sh"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "type-fest": "^3.10.0"
+  },
   "dependencies": {
     "@strapi/plugin-graphql": "4.10.5",
     "@strapi/plugin-i18n": "4.10.5",

--- a/apps/api/src/api/activity/controllers/activity.ts
+++ b/apps/api/src/api/activity/controllers/activity.ts
@@ -1,3 +1,18 @@
 import { factories } from '@strapi/strapi'
 
-export default factories.createCoreController('api::activity.activity')
+export default factories.createCoreController(
+  'api::activity.activity',
+  ({ strapi }) => {
+    return {
+      async create(ctx) {
+        const result = await super.create(ctx)
+
+        await strapi
+          .service('api::activity.activity')
+          .update(result.data.id, { data: { creator: ctx.state.user.id } })
+
+        return result
+      },
+    }
+  },
+)

--- a/apps/api/src/api/user-statistic/content-types/user-statistic/schema.json
+++ b/apps/api/src/api/user-statistic/content-types/user-statistic/schema.json
@@ -17,15 +17,11 @@
       "relation": "oneToOne",
       "target": "plugin::users-permissions.user"
     },
-    "type": {
-      "type": "enumeration",
-      "enum": ["creator", "approver"]
-    },
-    "blog": {
-      "type": "integer"
-    },
     "date": {
       "type": "date"
+    },
+    "stats": {
+      "type": "json"
     }
   }
 }

--- a/apps/api/src/api/user-statistic/routes/custom.ts
+++ b/apps/api/src/api/user-statistic/routes/custom.ts
@@ -2,8 +2,13 @@ export default {
   routes: [
     {
       method: 'GET',
-      path: '/user-statistics/findCustom/:id',
-      handler: 'custom.findCustom',
+      path: '/user-statistics/get-stats/me',
+      handler: 'custom.getMyStats',
+    },
+    {
+      method: 'GET',
+      path: '/user-statistics/get-stats',
+      handler: 'custom.getStats',
     },
   ],
 }

--- a/apps/api/src/libs/getStats.ts
+++ b/apps/api/src/libs/getStats.ts
@@ -3,7 +3,22 @@ import formatIso from 'date-fns/formatISO'
 import { kebabCase } from 'lodash'
 import { KebabCase } from 'type-fest'
 
-const models = {
+type ModelKey =
+  | 'activity'
+  | 'announcement'
+  | 'application'
+  | 'blog'
+  | 'collection'
+  | 'competition'
+  | 'hashtag'
+  | 'post'
+  | 'recommendedTopic'
+  | 'recommendedTweet'
+type ModelApiKey<T extends ModelKey> = `api::${KebabCase<T>}.${KebabCase<T>}`
+type StatsType = 'creator' | 'approver'
+
+// Some models might not have approvers
+const models: Record<ModelKey, StatsType[]> = {
   activity: ['creator', 'approver'],
   announcement: ['creator', 'approver'],
   application: ['creator', 'approver'],
@@ -15,11 +30,6 @@ const models = {
   recommendedTopic: ['creator'],
   recommendedTweet: ['creator'],
 }
-
-const modelKeys = Object.keys(models) as Array<keyof typeof models>
-
-type ModelKey = keyof typeof models
-type ModelApiKey<T extends ModelKey> = `api::${KebabCase<T>}.${KebabCase<T>}`
 
 const getModelStats = async <T extends ModelKey>(
   type: 'creator' | 'approver',
@@ -46,12 +56,9 @@ export async function getStats(
   const start = formatIso(addDays(date, -totalDays))
   const end = formatIso(date)
 
-  const statsTypes = ['creator', 'approver'] as ['creator', 'approver']
-
-  const stats = {} as Record<
-    (typeof statsTypes)[number],
-    Record<ModelKey | 'total', number>
-  >
+  const statsTypes = ['creator', 'approver'] as StatsType[]
+  const modelKeys = Object.keys(models) as ModelKey[]
+  const stats = {} as Record<StatsType, Record<ModelKey | 'total', number>>
 
   for (const type of statsTypes) {
     for (const modelKey of modelKeys) {

--- a/apps/api/src/libs/getStats.ts
+++ b/apps/api/src/libs/getStats.ts
@@ -1,231 +1,82 @@
 import addDays from 'date-fns/addDays'
 import formatIso from 'date-fns/formatISO'
+import { kebabCase } from 'lodash'
+import { KebabCase } from 'type-fest'
+
+const models = {
+  activity: ['creator', 'approver'],
+  announcement: ['creator', 'approver'],
+  application: ['creator', 'approver'],
+  blog: ['creator', 'approver'],
+  collection: ['creator', 'approver'],
+  competition: ['creator', 'approver'],
+  hashtag: ['creator', 'approver'],
+  post: ['creator', 'approver'],
+  recommendedTopic: ['creator'],
+  recommendedTweet: ['creator'],
+}
+
+const modelKeys = Object.keys(models) as Array<keyof typeof models>
+
+type ModelKey = keyof typeof models
+type ModelApiKey<T extends ModelKey> = `api::${KebabCase<T>}.${KebabCase<T>}`
+
+const getModelStats = async <T extends ModelKey>(
+  type: 'creator' | 'approver',
+  modelKey: ModelApiKey<T>,
+  userId: number,
+  start: string,
+  end: string,
+) => {
+  return await strapi.db.query(modelKey).count({
+    where: {
+      [type]: userId,
+      createdAt: {
+        $between: [start, end],
+      },
+    },
+  })
+}
 
 export async function getStats(
   userId: number,
   date = new Date(),
   totalDays = 7,
 ) {
-  const start_time = formatIso(addDays(date, -totalDays))
-  const end_time = formatIso(date)
+  const start = formatIso(addDays(date, -totalDays))
+  const end = formatIso(date)
 
-  const activityCreatorCount = await strapi.db
-    .query('api::activity.activity')
-    .count({
-      where: {
-        creator: userId,
-        createdAt: {
-          $between: [start_time, end_time],
-        },
-      },
-    })
+  const statsTypes = ['creator', 'approver'] as ['creator', 'approver']
 
-  const activityApproverCount = await strapi.db
-    .query('api::activity.activity')
-    .count({
-      where: {
-        approver: userId,
-        createdAt: {
-          $between: [start_time, end_time],
-        },
-      },
-    })
+  const stats = {} as Record<
+    (typeof statsTypes)[number],
+    Record<ModelKey | 'total', number>
+  >
 
-  const announcementCreatorCount = await strapi.db
-    .query('api::announcement.announcement')
-    .count({
-      where: {
-        creator: userId,
-        createdAt: {
-          $between: [start_time, end_time],
-        },
-      },
-    })
+  for (const type of statsTypes) {
+    for (const modelKey of modelKeys) {
+      if (!models[modelKey].includes(type)) continue
 
-  const announcementApproverCount = await strapi.db
-    .query('api::announcement.announcement')
-    .count({
-      where: {
-        approver: userId,
-        createdAt: {
-          $between: [start_time, end_time],
-        },
-      },
-    })
+      const apiPath = kebabCase(modelKey) as KebabCase<ModelKey>
 
-  const applicationCreatorCount = await strapi.db
-    .query('api::application.application')
-    .count({
-      where: {
-        creator: userId,
-        createdAt: {
-          $between: [start_time, end_time],
-        },
-      },
-    })
+      const count = await getModelStats(
+        type,
+        `api::${apiPath}.${apiPath}`,
+        userId,
+        start,
+        end,
+      )
 
-  const applicationApproverCount = await strapi.db
-    .query('api::application.application')
-    .count({
-      where: {
-        approver: userId,
-        createdAt: {
-          $between: [start_time, end_time],
-        },
-      },
-    })
-
-  const blogCreatorCount = await strapi.db.query('api::blog.blog').count({
-    where: {
-      creator: userId,
-      createdAt: {
-        $between: [start_time, end_time],
-      },
-    },
-  })
-
-  const blogApproverCount = await strapi.db.query('api::blog.blog').count({
-    where: {
-      approver: userId,
-      createdAt: {
-        $between: [start_time, end_time],
-      },
-    },
-  })
-
-  const collectionCreatorCount = await strapi.db
-    .query('api::collection.collection')
-    .count({
-      where: {
-        creator: userId,
-        createdAt: {
-          $between: [start_time, end_time],
-        },
-      },
-    })
-
-  const collectionApproverCount = await strapi.db
-    .query('api::collection.collection')
-    .count({
-      where: {
-        approver: userId,
-        createdAt: {
-          $between: [start_time, end_time],
-        },
-      },
-    })
-
-  const competitionCreatorCount = await strapi.db
-    .query('api::competition.competition')
-    .count({
-      where: {
-        creator: userId,
-        createdAt: {
-          $between: [start_time, end_time],
-        },
-      },
-    })
-
-  const competitionApproverCount = await strapi.db
-    .query('api::competition.competition')
-    .count({
-      where: {
-        approver: userId,
-        createdAt: {
-          $between: [start_time, end_time],
-        },
-      },
-    })
-
-  const hashtagCreatorCount = await strapi.db
-    .query('api::hashtag.hashtag')
-    .count({
-      where: {
-        creator: userId,
-        createdAt: {
-          $between: [start_time, end_time],
-        },
-      },
-    })
-
-  const hashtagApproverCount = await strapi.db
-    .query('api::hashtag.hashtag')
-    .count({
-      where: {
-        approver: userId,
-        createdAt: {
-          $between: [start_time, end_time],
-        },
-      },
-    })
-
-  const postCreatorCount = await strapi.db.query('api::post.post').count({
-    where: {
-      creator: userId,
-      createdAt: {
-        $between: [start_time, end_time],
-      },
-    },
-  })
-
-  const postApproverCount = await strapi.db.query('api::post.post').count({
-    where: {
-      approver: userId,
-      createdAt: {
-        $between: [start_time, end_time],
-      },
-    },
-  })
-
-  const recommendedTopicCreatorCount = await strapi.db
-    .query('api::recommended-topic.recommended-topic')
-    .count({
-      where: {
-        creator: userId,
-        createdAt: {
-          $between: [start_time, end_time],
-        },
-      },
-    })
-
-  const recommendedTweetCreatorCount = await strapi.db
-    .query('api::recommended-tweet.recommended-tweet')
-    .count({
-      where: {
-        creator: userId,
-        createdAt: {
-          $between: [start_time, end_time],
-        },
-      },
-    })
-
-  // add more queries as new collections get added with approver/creator fields
-
-  const totalCreatorCount =
-    activityCreatorCount +
-    announcementCreatorCount +
-    applicationCreatorCount +
-    blogCreatorCount +
-    collectionCreatorCount +
-    competitionCreatorCount +
-    hashtagCreatorCount +
-    postCreatorCount +
-    recommendedTopicCreatorCount +
-    recommendedTweetCreatorCount
-
-  const totalApproverCount =
-    activityApproverCount +
-    announcementApproverCount +
-    applicationApproverCount +
-    blogApproverCount +
-    collectionApproverCount +
-    competitionApproverCount +
-    hashtagApproverCount +
-    postApproverCount
+      stats[type] = {
+        ...stats[type],
+        [modelKey]: count,
+        total: (stats[type]?.total ?? 0) + count,
+      }
+    }
+  }
 
   return {
-    userId: userId,
-    creatorCount: totalCreatorCount,
-    approverCount: totalApproverCount,
+    approves: stats.approver,
+    creations: stats.creator,
   }
 }

--- a/apps/api/yarn.lock
+++ b/apps/api/yarn.lock
@@ -10692,6 +10692,11 @@ type-fest@^2.0.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
   integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
 
+type-fest@^3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.10.0.tgz#d75f17a22be8816aea6315ab2739fe1c0c211863"
+  integrity sha512-hmAPf1datm+gt3c2mvu0sJyhFy6lTkIGf0GzyaZWxRLnabQfPUqg6tF95RPg6sLxKI7nFLGdFxBcf2/7+GXI+A==
+
 type-is@^1.6.14, type-is@^1.6.16, type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"

--- a/libs/types/src/strapi.ts
+++ b/libs/types/src/strapi.ts
@@ -248,6 +248,8 @@ export type StrapiCollectionUrl =
   | 'timelines'
   | 'tweet-users'
   | 'tweets'
+  | 'user-stats'
+  | 'user-stats/me'
   | 'users'
   | 'users/me'
   | 'volunteers'

--- a/libs/types/src/user-stats.ts
+++ b/libs/types/src/user-stats.ts
@@ -1,14 +1,36 @@
 import { StrapiBase } from './strapi'
 import { User } from './user'
 
+export type UserStatsApproves = {
+  activity: number
+  total: number
+  announcement: number
+  application: number
+  blog: number
+  collection: number
+  competition: number
+  hashtag: number
+  post: number
+}
+
+export type UserStatsCreations = UserStatsApproves & {
+  recommendedTopic: number
+  recommendedTweet: number
+}
+
+export type UserStatsData = {
+  approves: UserStatsApproves
+  creations: UserStatsCreations
+}
+
 export type UserStatsBase = StrapiBase & {
   date: string
   count: number
-  type: 'creator' | 'approver'
+  stats: UserStatsData
 }
 
 type UserStatsRelation = {
-  user: User
+  user: Pick<User, 'id' | 'name' | 'username'>
 }
 
 export type UserStats = UserStatsBase & UserStatsRelation


### PR DESCRIPTION
@MSKose I merged latest dev into your branch. I noticed that the current model on which we talked had some missing parts. I updated the functionality according to our needs. Please review it and you can merge `user-stats` => `401-user-stats` and then `401-user-stast` => `dev` if everything works for you.

### Permissions

Keep in mind that you should give a permission to a role (e.g. admin) for newly created custom stats routes from Strapi dashboard.

<img width="1190" alt="user-stats" src="https://github.com/wsvvrijheid/monorepo/assets/22167684/fb65c312-caf1-4a51-ab3a-bf4a32a53d05">

### Custom fetch

Normally, we wanted to save user statistics on a weekly basis to avoid users making potentially overkill database calls. I'm not sure if these `.count` requests are really heavy. That's why I add a new custom route that allows us to fetch the current or past stats.

In the new route `/api/user-statistics/get-stats?date=2023-04-12&date=40`, we can specify date and days params.

We will most likely use `/api/user-statistics` to retrieve stats saved in the cron process. But if the custom route won't cause any performance issue, we might also use it for instant comparisons.