### PR TITLE
Fix updating user role

### DIFF
--- a/apps/dashboard/public/locales/en/common.json
+++ b/apps/dashboard/public/locales/en/common.json
@@ -285,6 +285,7 @@
   "view-collections": "View Collections",
   "views": "Views",
   "visit-website": "Visit Website",
+  "volunteer": "Volunteer",
   "volunteers": "Volunteers",
   "votes": "Votes",
   "weeksWithCount_one": "1 week",

--- a/apps/dashboard/public/locales/nl/common.json
+++ b/apps/dashboard/public/locales/nl/common.json
@@ -283,6 +283,7 @@
   "view-collections": "Bekijk Collecties",
   "views": "Weergaven",
   "visit-website": "Bezoek Website",
+  "volunteer": "Vrijwilliger",
   "volunteers": "Vrijveligers",
   "votes": "Stemmen",
   "weeksWithCount_one": "1 week",

--- a/apps/dashboard/public/locales/tr/common.json
+++ b/apps/dashboard/public/locales/tr/common.json
@@ -284,6 +284,7 @@
   "view-collections": "Koleksiyonlara Gözat",
   "views": "Gözatmalar",
   "visit-website": "Web sitesini ziyaret et",
+  "volunteer": "Gönüllü",
   "volunteers": "Gönüllüler",
   "votes": "Oylar",
   "weeksWithCount_one": "1 hafta",

--- a/apps/foundation/public/locales/en/common.json
+++ b/apps/foundation/public/locales/en/common.json
@@ -285,6 +285,7 @@
   "view-collections": "View Collections",
   "views": "Views",
   "visit-website": "Visit Website",
+  "volunteer": "Volunteer",
   "volunteers": "Volunteers",
   "votes": "Votes",
   "weeksWithCount_one": "1 week",

--- a/apps/foundation/public/locales/nl/common.json
+++ b/apps/foundation/public/locales/nl/common.json
@@ -283,6 +283,7 @@
   "view-collections": "Bekijk Collecties",
   "views": "Weergaven",
   "visit-website": "Bezoek Website",
+  "volunteer": "Vrijwilliger",
   "volunteers": "Vrijveligers",
   "votes": "Stemmen",
   "weeksWithCount_one": "1 week",

--- a/apps/foundation/public/locales/tr/common.json
+++ b/apps/foundation/public/locales/tr/common.json
@@ -284,6 +284,7 @@
   "view-collections": "Koleksiyonlara Gözat",
   "views": "Gözatmalar",
   "visit-website": "Web sitesini ziyaret et",
+  "volunteer": "Gönüllü",
   "volunteers": "Gönüllüler",
   "votes": "Oylar",
   "weeksWithCount_one": "1 hafta",

--- a/apps/kunsthalte/public/locales/en/common.json
+++ b/apps/kunsthalte/public/locales/en/common.json
@@ -285,6 +285,7 @@
   "view-collections": "View Collections",
   "views": "Views",
   "visit-website": "Visit Website",
+  "volunteer": "Volunteer",
   "volunteers": "Volunteers",
   "votes": "Votes",
   "weeksWithCount_one": "1 week",

--- a/apps/kunsthalte/public/locales/nl/common.json
+++ b/apps/kunsthalte/public/locales/nl/common.json
@@ -283,6 +283,7 @@
   "view-collections": "Bekijk Collecties",
   "views": "Weergaven",
   "visit-website": "Bezoek Website",
+  "volunteer": "Vrijwilliger",
   "volunteers": "Vrijveligers",
   "votes": "Stemmen",
   "weeksWithCount_one": "1 week",

--- a/apps/kunsthalte/public/locales/tr/common.json
+++ b/apps/kunsthalte/public/locales/tr/common.json
@@ -284,6 +284,7 @@
   "view-collections": "Koleksiyonlara Gözat",
   "views": "Gözatmalar",
   "visit-website": "Web sitesini ziyaret et",
+  "volunteer": "Gönüllü",
   "volunteers": "Gönüllüler",
   "votes": "Oylar",
   "weeksWithCount_one": "1 hafta",

--- a/apps/lotus/public/locales/en/common.json
+++ b/apps/lotus/public/locales/en/common.json
@@ -285,6 +285,7 @@
   "view-collections": "View Collections",
   "views": "Views",
   "visit-website": "Visit Website",
+  "volunteer": "Volunteer",
   "volunteers": "Volunteers",
   "votes": "Votes",
   "weeksWithCount_one": "1 week",

--- a/apps/lotus/public/locales/nl/common.json
+++ b/apps/lotus/public/locales/nl/common.json
@@ -283,6 +283,7 @@
   "view-collections": "Bekijk Collecties",
   "views": "Weergaven",
   "visit-website": "Bezoek Website",
+  "volunteer": "Vrijwilliger",
   "volunteers": "Vrijveligers",
   "votes": "Stemmen",
   "weeksWithCount_one": "1 week",

--- a/apps/lotus/public/locales/tr/common.json
+++ b/apps/lotus/public/locales/tr/common.json
@@ -284,6 +284,7 @@
   "view-collections": "Koleksiyonlara Gözat",
   "views": "Gözatmalar",
   "visit-website": "Web sitesini ziyaret et",
+  "volunteer": "Gönüllü",
   "volunteers": "Gönüllüler",
   "votes": "Oylar",
   "weeksWithCount_one": "1 hafta",

--- a/apps/samenvvv/public/locales/en/common.json
+++ b/apps/samenvvv/public/locales/en/common.json
@@ -285,6 +285,7 @@
   "view-collections": "View Collections",
   "views": "Views",
   "visit-website": "Visit Website",
+  "volunteer": "Volunteer",
   "volunteers": "Volunteers",
   "votes": "Votes",
   "weeksWithCount_one": "1 week",

--- a/apps/samenvvv/public/locales/nl/common.json
+++ b/apps/samenvvv/public/locales/nl/common.json
@@ -283,6 +283,7 @@
   "view-collections": "Bekijk Collecties",
   "views": "Weergaven",
   "visit-website": "Bezoek Website",
+  "volunteer": "Vrijwilliger",
   "volunteers": "Vrijveligers",
   "votes": "Stemmen",
   "weeksWithCount_one": "1 week",

--- a/apps/samenvvv/public/locales/tr/common.json
+++ b/apps/samenvvv/public/locales/tr/common.json
@@ -284,6 +284,7 @@
   "view-collections": "Koleksiyonlara Gözat",
   "views": "Gözatmalar",
   "visit-website": "Web sitesini ziyaret et",
+  "volunteer": "Gönüllü",
   "volunteers": "Gönüllüler",
   "votes": "Oylar",
   "weeksWithCount_one": "1 hafta",

--- a/packages/lib/src/mutation/mutation.ts
+++ b/packages/lib/src/mutation/mutation.ts
@@ -13,6 +13,12 @@ import { generateFormData } from '@wsvvrijheid/utils'
 
 type Method = 'post' | 'put' | 'delete' | 'localize'
 
+type MutationBody =
+  | StrapiCreateInput
+  | StrapiUpdateInput
+  | { data: StrapiCreateInput | StrapiUpdateInput }
+  | FormData
+
 type MutationParams<D> = {
   body?: D
   id?: number
@@ -37,11 +43,6 @@ export const mutation = async <
   endpoint,
   queryParameters,
 }: MutationParams<D>) => {
-  //  Throw an error if the body is not provided
-  if (method !== 'delete' && !body) {
-    throw new Error(`Body is required for ${method} method`)
-  }
-
   //  Throw an error if the id is not provided
   if (method !== 'post' && !id) {
     throw new Error(`Id is required for ${method} method`)
@@ -80,16 +81,29 @@ export const mutation = async <
     return response.data?.data || null
   }
 
-  let requestBody = { data: body } as unknown as FormData
+  //  Throw an error if the body is not provided
+  if (!body) {
+    throw new Error(`Body is required for ${method} method`)
+  }
 
-  if (
-    typeof window !== 'undefined' &&
-    body &&
-    Object.values(body).some(
-      value => value instanceof File || value instanceof Blob,
-    )
-  ) {
-    requestBody = generateFormData<D>(body)
+  console.log('body', body)
+
+  const endpointsWithoutDataField: StrapiEndpoint[] = ['users', 'users/me']
+  const hasBodyDataField = !endpointsWithoutDataField.includes(endpoint)
+
+  let requestBody: MutationBody = hasBodyDataField
+    ? ({ data: body } as { data: D })
+    : body
+
+  console.log('A', requestBody)
+
+  const hasBodyFile = Object.values(body).some(
+    value => value instanceof File || value instanceof Blob,
+  )
+
+  if (hasBodyFile) {
+    requestBody = generateFormData<D>(body, hasBodyDataField)
+    console.log('B', requestBody)
   }
 
   try {

--- a/packages/lib/src/mutation/mutation.ts
+++ b/packages/lib/src/mutation/mutation.ts
@@ -86,8 +86,6 @@ export const mutation = async <
     throw new Error(`Body is required for ${method} method`)
   }
 
-  console.log('body', body)
-
   const endpointsWithoutDataField: StrapiEndpoint[] = ['users', 'users/me']
   const hasBodyDataField = !endpointsWithoutDataField.includes(endpoint)
 
@@ -95,15 +93,12 @@ export const mutation = async <
     ? ({ data: body } as { data: D })
     : body
 
-  console.log('A', requestBody)
-
   const hasBodyFile = Object.values(body).some(
     value => value instanceof File || value instanceof Blob,
   )
 
   if (hasBodyFile) {
     requestBody = generateFormData<D>(body, hasBodyDataField)
-    console.log('B', requestBody)
   }
 
   try {

--- a/packages/ui/public/locales/en/common.json
+++ b/packages/ui/public/locales/en/common.json
@@ -285,6 +285,7 @@
   "view-collections": "View Collections",
   "views": "Views",
   "visit-website": "Visit Website",
+  "volunteer": "Volunteer",
   "volunteers": "Volunteers",
   "votes": "Votes",
   "weeksWithCount_one": "1 week",

--- a/packages/ui/public/locales/nl/common.json
+++ b/packages/ui/public/locales/nl/common.json
@@ -283,6 +283,7 @@
   "view-collections": "Bekijk Collecties",
   "views": "Weergaven",
   "visit-website": "Bezoek Website",
+  "volunteer": "Vrijwilliger",
   "volunteers": "Vrijveligers",
   "votes": "Stemmen",
   "weeksWithCount_one": "1 week",

--- a/packages/ui/public/locales/tr/common.json
+++ b/packages/ui/public/locales/tr/common.json
@@ -284,6 +284,7 @@
   "view-collections": "Koleksiyonlara Gözat",
   "views": "Gözatmalar",
   "visit-website": "Web sitesini ziyaret et",
+  "volunteer": "Gönüllü",
   "volunteers": "Gönüllüler",
   "votes": "Oylar",
   "weeksWithCount_one": "1 hafta",

--- a/packages/ui/src/admin/ModelForm/ModelEditForm.tsx
+++ b/packages/ui/src/admin/ModelForm/ModelEditForm.tsx
@@ -46,7 +46,7 @@ import {
 
 import { ModelMedia } from './ModelMedia'
 import { ModelSelect } from './ModelSelect'
-import { ModelEditFormProps, Option } from './types'
+import { FormCommonFields, ModelEditFormProps, Option } from './types'
 import { useDefaultValues } from './utils'
 import { I18nNamespaces } from '../../../@types/i18next'
 import { FormItem, MasonryGrid, MdFormItem } from '../../components'
@@ -157,6 +157,7 @@ export const ModelEditForm = <T extends StrapiModel>({
   const onSaveModel = async (
     data: Record<string, string | File | Option | Option[]>,
   ) => {
+    console.log('data', data)
     const body = Object.entries(data).reduce((acc, [key, value]) => {
       if (value === undefined || !fields.some(f => f.name === key)) {
         return acc
@@ -182,7 +183,13 @@ export const ModelEditForm = <T extends StrapiModel>({
       }
     }, {} as StrapiTranslatableUpdateInput)
 
-    updateModelMutation.mutate({ id, ...body }, { onSuccess: handleSuccess })
+    // TODO: Why avatar comes as string? "[data: Blob]"
+    const avatar = endpoint === 'users' ? watch('avatar') : undefined
+
+    updateModelMutation.mutate(
+      { id, ...body, ...(avatar && { avatar }) },
+      { onSuccess: handleSuccess },
+    )
   }
 
   const onCancel = () => {
@@ -245,6 +252,12 @@ export const ModelEditForm = <T extends StrapiModel>({
     })
   }
 
+  const toggleChangingMedia = (field: FormCommonFields<T>) =>
+    setIsChangingImage(prev => ({
+      ...prev,
+      [field.name]: isChangingImage[field.name as string] ? false : true,
+    }))
+
   const disabledStyle = {
     borderColor: 'transparent',
     _hover: { borderColor: 'transparent' },
@@ -296,14 +309,7 @@ export const ModelEditForm = <T extends StrapiModel>({
                       name={field.name as string}
                       setValue={setValue}
                       isChangingMedia={isChangingImage[field.name as string]}
-                      toggleChangingMedia={() =>
-                        setIsChangingImage(prev => ({
-                          ...prev,
-                          [field.name]: isChangingImage[field.name as string]
-                            ? false
-                            : true,
-                        }))
-                      }
+                      toggleChangingMedia={() => toggleChangingMedia(field)}
                     />
                     <FormErrorMessage>
                       {errors[field.name as string]?.message as string}

--- a/packages/ui/src/admin/ModelForm/ModelEditForm.tsx
+++ b/packages/ui/src/admin/ModelForm/ModelEditForm.tsx
@@ -157,7 +157,6 @@ export const ModelEditForm = <T extends StrapiModel>({
   const onSaveModel = async (
     data: Record<string, string | File | Option | Option[]>,
   ) => {
-    console.log('data', data)
     const body = Object.entries(data).reduce((acc, [key, value]) => {
       if (value === undefined || !fields.some(f => f.name === key)) {
         return acc

--- a/packages/ui/src/admin/ModelForm/ModelMedia.tsx
+++ b/packages/ui/src/admin/ModelForm/ModelMedia.tsx
@@ -27,8 +27,8 @@ export const ModelMedia = <T extends FieldValues = FieldValues>({
   setValue,
   model,
   isEditing,
-  isChangingMedia: isChangingImage,
-  toggleChangingMedia: toggleChangingImage,
+  isChangingMedia,
+  toggleChangingMedia,
   endpoint,
   name,
 }: ModelMediaProps<T>) => {
@@ -40,10 +40,10 @@ export const ModelMedia = <T extends FieldValues = FieldValues>({
   const mediaUrl = getMediaUrl(media)
 
   const renderMedia = () => {
-    if (isChangingImage || (isEditing && !media)) {
+    if (isChangingMedia || (isEditing && !media)) {
       return (
         <Stack>
-          {media && <Button onClick={toggleChangingImage}>Cancel</Button>}
+          {media && <Button onClick={toggleChangingMedia}>Cancel</Button>}
           <FilePicker
             onLoaded={files =>
               setValue(name as Path<T>, files[0] as PathValue<T, Path<T>>)
@@ -105,14 +105,14 @@ export const ModelMedia = <T extends FieldValues = FieldValues>({
       overflow="hidden"
     >
       {renderMedia()}
-      {isEditing && media && !isChangingImage && (
+      {isEditing && media && !isChangingMedia && (
         <Center
           pos="absolute"
           top={0}
           left={0}
           boxSize="full"
           bg="blackAlpha.500"
-          onClick={toggleChangingImage}
+          onClick={toggleChangingMedia}
           cursor="pointer"
         >
           <Button

--- a/packages/ui/src/admin/ModelForm/types.ts
+++ b/packages/ui/src/admin/ModelForm/types.ts
@@ -45,7 +45,7 @@ type FormSelectFields = {
   endpoint: StrapiCollectionEndpoint
 }
 
-type FormCommonFields<T extends StrapiModel> = {
+export type FormCommonFields<T extends StrapiModel> = {
   name: keyof T
   label?: string
   isRequired?: boolean

--- a/packages/ui/src/data/schemas/user.ts
+++ b/packages/ui/src/data/schemas/user.ts
@@ -24,7 +24,7 @@ export const userFields: FormFields<User> = [
     type: 'select',
     endpoint: 'volunteers',
   },
-  { name: 'avatar', isRequired: true, type: 'file' },
+  { name: 'avatar', type: 'file' },
   {
     name: 'role',
     type: 'select',

--- a/packages/utils/src/generateFormData.ts
+++ b/packages/utils/src/generateFormData.ts
@@ -4,6 +4,7 @@ export const generateFormData = <
   T extends StrapiCreateInput | StrapiUpdateInput,
 >(
   body: T,
+  hasDataField = true,
 ) => {
   const formData = new FormData()
 
@@ -33,7 +34,13 @@ export const generateFormData = <
     }
   })
 
-  formData.append('data', JSON.stringify(data))
+  if (hasDataField) {
+    formData.append('data', JSON.stringify(data))
+  } else {
+    Object.entries(data).forEach(([key, value]) => {
+      formData.append(key, value as string)
+    })
+  }
 
   return formData
 }


### PR DESCRIPTION
I noticed that `/users` endpoint expects body without `{ data: ... } ` field unlike the other endpoints.

I'm still unable to update `avatar`, we should probably adjust backend controller for that.